### PR TITLE
Fix: Spelling mistake

### DIFF
--- a/src/components/site/Platform.tsx
+++ b/src/components/site/Platform.tsx
@@ -42,7 +42,7 @@ const syncMap: {
     url: "https://{username}.substack.com/",
   },
   medium: {
-    name: "Mediam",
+    name: "Medium",
     icon: "/assets/social/medium.svg",
     url: "https://medium.com/@{username}",
   },


### PR DESCRIPTION
Fixed spelling mistake from 'mediam' to 'medium'.