### PR TITLE
delete the bar's overflow-x-scroll

### DIFF
--- a/src/components/ui/Tabs.tsx
+++ b/src/components/ui/Tabs.tsx
@@ -15,7 +15,7 @@ export const Tabs: React.FC<{ items: TabItem[] }> = ({ items }) => {
   const { t } = useTranslation(["dashboard"])
 
   return (
-    <div className="flex border-b space-x-5 mb-8 overflow-x-scroll">
+    <div className="flex border-b space-x-5 mb-8">
       {items.map((item) => {
         if (item.hidden) return null
 


### PR DESCRIPTION
The tab bar's overflow-x-scroll looks strange.
So i delete the "overflow-x-scroll" attribute to make it look better.
before:
![图片](https://user-images.githubusercontent.com/36598604/222946833-14723320-766f-429b-b76b-567d6bba3bb4.png)
after:
![图片](https://user-images.githubusercontent.com/36598604/222946841-750a58b5-67cf-4fd5-a171-49297cc97541.png)
