### PR TITLE
fix: character card click event

### DIFF
--- a/src/components/common/CharacterCard.tsx
+++ b/src/components/common/CharacterCard.tsx
@@ -50,10 +50,14 @@ export const CharacterCard: React.FC<{
   return (
     <span
       className={cn(
-        "border-gray-100 rounded-lg text-sm block",
+        "border-gray-100 rounded-lg text-sm block cursor-default",
         style === "flat" ? "" : "p-4 bg-white shadow-xl",
         simple ? "space-y-1" : "space-y-2",
       )}
+      onClick={(e) => {
+        e.preventDefault()
+        e.stopPropagation()
+      }}
     >
       {site ? (
         <>


### PR DESCRIPTION
This prevents the bug where the clicking inside the card may trigger the outer a link clicking.

<img width="393" alt="image" src="https://user-images.githubusercontent.com/22665058/228122910-35f398fb-ae68-4fd6-b013-092b81c1d025.png">
