### PR TITLE
fix: adjust disclosure icon

### DIFF
--- a/src/components/common/BlockchainInfo.tsx
+++ b/src/components/common/BlockchainInfo.tsx
@@ -39,7 +39,7 @@ export const BlockchainInfo: React.FC<{
               </span>
               <span
                 className={cn(
-                  "i-mingcute:down-line text-lg text-gray-500 transform transition-transform",
+                  "i-mingcute:up-line text-lg text-gray-500 transform transition-transform",
                   open ? "" : "rotate-180",
                 )}
               ></span>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f56640</samp>

Updated the icon and animation for the blockchain info panel in `BlockchainInfo.tsx` to match the design mockup.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5f56640</samp>

> _`icon` rotates_
> _collapsible panel matches_
> _mockup in springtime_

### WHY

When opened, it would be more reasonable for the arrow to point upwards.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5f56640</samp>

* Changed the icon for the blockchain info panel toggle button to match the design mockup ([link](https://github.com/Crossbell-Box/xLog/pull/306/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL42-R42))
