### PR TITLE
fix: TextNode error in Footer while using Google Translate

### DIFF
--- a/public/locales/ja/site.json
+++ b/public/locales/ja/site.json
@@ -6,5 +6,5 @@
   "load more": "まだ{{count}}件の{{name}}があります。",
   "signed and stored on the blockchain": "{{name}}は、創作者によって署名され、ブロックチェーンに安全に保存されています。",
   "Write a comment on the blockchain": "ブロックチェーンでコメントする",
-  "powered by": "このサイトは　<name/> によって作動します"
+  "powered by": "<span>このサイトは　</span><name/><span> によって作動します</span>"
 }

--- a/public/locales/zh-TW/site.json
+++ b/public/locales/zh-TW/site.json
@@ -6,7 +6,7 @@
   "load more": "還有{{count}}篇{{name}}，點選載入更多文章",
   "signed and stored on the blockchain": "此{{name}}已由它的創作者簽名並安全儲存在區塊鏈上。",
   "Write a comment on the blockchain": "在區塊鏈上留言。",
-  "powered by": "由 <name/> 提供支援",
+  "powered by": "<span>由 </span><name/><span> 提供支援</span>",
   "This address is in local editing preview mode and cannot be viewed by the public. The expected online address is:": "此地址處於本地編輯預覽模式，尚未公開。預期的上線地址是：",
   "View on xChar": "在 xChar 上檢視",
   "View on xFeed": "在 xFeed 上檢視",

--- a/public/locales/zh/site.json
+++ b/public/locales/zh/site.json
@@ -6,7 +6,7 @@
   "load more": "还有 {{count}} 篇{{name}}，点击加载更多",
   "signed and stored on the blockchain": "此{{name}}已经由它的创作者签名并安全地存储在区块链上。",
   "Write a comment on the blockchain": "在区块链上写下你的评论",
-  "powered by": "由 <name/> 提供支持",
+  "powered by": "<span>由 </span><name/><span> 提供支持</span>",
   "This address is in local editing preview mode and cannot be viewed by the public. The expected online address is:":
     "此地址处于本地编辑预览模式，无法被公众查看。预期的在线地址是：",
   "View on xChar": "在 xChar 上查看",

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -34,16 +34,17 @@ export const SiteFooter: React.FC<{
       <footer className="text-zinc-500 border-t">
         <div className="max-w-screen-md mx-auto px-5 py-10 text-xs flex justify-between">
           <div className="font-medium text-base">
-            &copy;{" "}
+            <span>&copy; </span>
             <UniLink href="/" className="hover:text-accent">
-              {site?.name}
-            </UniLink>{" "}
-            ·{" "}
+              <span>{site?.name}</span>
+            </UniLink>
+            <span> · </span>
             <Trans
               i18nKey="powered by"
-              defaults={"Powered by <name/>"}
+              defaults={"<span>Powered by </span><name/>"}
               components={{
                 name: <LogoWithLink />,
+                span: <span />,
               }}
               ns="site"
             />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2766536</samp>

No summary available (The summary was empty or could not be parsed)

copilot:poem

### WHY
If there is a TextNode node, when using Google Translate for global translation, it will be forcibly wrapped in a font tag. This behavior can cause internal errors in React. For more details, see https://github.com/facebook/react/issues/11538.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2766536</samp>

*  Fix layout issue of "powered by" message in footer by wrapping text around `<name/>` component with `<span>` tags in Japanese, Traditional Chinese, and Simplified Chinese translations ([link](https://github.com/Crossbell-Box/xLog/pull/313/files?diff=unified&w=0#diff-0fc1218f1661a63357d22421792edc623ba08e6bb349ced84c906caa02581dc5L9-R9), [link](https://github.com/Crossbell-Box/xLog/pull/313/files?diff=unified&w=0#diff-64848babb2388f011d4fc0f656b94a793e5ba6f860e07bfebe546e7c42bd4986L9-R9), [link](https://github.com/Crossbell-Box/xLog/pull/313/files?diff=unified&w=0#diff-f6832913e1ed4ec6b7f662cdfff46da6a06bbeb94085efe97d8637cc66823289L9-R9))
