### PR TITLE
fix: dark mode flicker

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -81,7 +81,7 @@ const useDarkMode = (
   }, [storageKey])
 
   useEffect(() => {
-    if (isServerSide()) {
+    if (isServerSide() || typeof darkMode === "undefined") {
       return
     }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c61161</samp>

Improved the `useDarkMode` hook to avoid errors during server-side rendering and state initialization. Added checks for `darkMode` state and `localStorage` and `document` availability in `src/hooks/useDarkMode.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7c61161</samp>

> _`useDarkMode` checks_
> _undefined state before use_
> _autumn leaves falling_

### WHY
<!-- author to complete -->
In dark mode, there will be a flicker from black to white and back to black when the page is first loaded.Because useEffect was executed twice.

https://user-images.githubusercontent.com/89030875/231769430-eb35e69b-0273-4253-9bcb-729aa3343d02.mov


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7c61161</samp>

*  Prevent errors when accessing `localStorage` and `document` in `useDarkMode` hook ([link](https://github.com/Crossbell-Box/xLog/pull/331/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L84-R84))
