### PR TITLE
feat: improve readability in dark mode

### DIFF
--- a/src/components/common/AchievementModal.tsx
+++ b/src/components/common/AchievementModal.tsx
@@ -103,10 +103,10 @@ export const AchievementModal: React.FC<{
             />
           </Tilt>
           <div className="inline-flex flex-col flex-1 min-w-0 w-full space-y-1">
-            <span className="capitalize text-4xl font-medium truncate">
+            <span className="capitalize text-black text-4xl font-medium truncate">
               {group.info.title} {achievement && `#${achievement.tokenId}`}
             </span>
-            <span className="text-lg text-gray-100 capitalize truncate">
+            <span className="text-lg text-black capitalize truncate">
               {
                 (achievement || achievementMintable || achievementComming)!.info
                   .description

--- a/src/components/common/CharacterCard.tsx
+++ b/src/components/common/CharacterCard.tsx
@@ -51,7 +51,7 @@ export const CharacterCard: React.FC<{
   return (
     <span
       className={cn(
-        "border-gray-100 rounded-lg text-sm block cursor-default",
+        "border-border border rounded-lg text-sm block cursor-default",
         style === "flat" ? "" : "p-4 bg-white shadow-xl",
         simple ? "space-y-1" : "space-y-2",
       )}

--- a/src/components/common/ConnectButton.tsx
+++ b/src/components/common/ConnectButton.tsx
@@ -278,7 +278,7 @@ export const ConnectButton: React.FC<{
                   }
                   dropdown={
                     <div
-                      className={`text-gray-600 bg-white rounded-lg ring-1 ring-zinc-100 min-w-[140px] shadow-md py-2 ${
+                      className={`text-gray-600 bg-white rounded-lg ring-1 ring-border min-w-[140px] shadow-md py-2 ${
                         size === "base" ? "text-base" : "text-sm"
                       } mt-1`}
                     >

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -43,6 +43,7 @@ export const Logo: React.FC<{
             width: width || 100,
             height: height || 100,
           }}
+          className="xlog-lottie-logo"
         />
       )
   }

--- a/src/components/dashboard/PagesManagerMenu.tsx
+++ b/src/components/dashboard/PagesManagerMenu.tsx
@@ -166,7 +166,7 @@ export const PagesManagerMenu: FC<{
   }, [])
 
   return (
-    <Menu.Items className="text-sm absolute z-20 right-0 bg-white shadow-modal rounded-lg overflow-hidden py-2 w-64">
+    <Menu.Items className="text-sm absolute z-20 right-0 bg-white shadow-modal rounded-lg overflow-hidden py-2 w-64 ring-1 ring-border">
       {items.map((item) => {
         return (
           <Menu.Item key={item.text}>

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -259,7 +259,7 @@ export const SiteHeader: React.FC<{
                         </Button>
                       }
                       dropdown={
-                        <div className="text-gray-600 bg-white rounded-lg ring-1 ring-zinc-100 shadow-md py-2 text-sm">
+                        <div className="text-gray-600 bg-white rounded-lg ring-1 ring-border shadow-md py-2 text-sm">
                           {moreMenuItems.map((item) => {
                             return (
                               <UniLink

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -364,3 +364,7 @@ textarea.input {
   border-right-color: currentColor;
   @apply animate-spin;
 }
+
+.xlog-lottie-logo path[fill="rgb(0,0,0)"] {
+  @apply fill-current;
+}

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -21,6 +21,10 @@
   border-color: var(--border-color);
 }
 
+html.dark {
+  color-scheme: dark;
+}
+
 body {
   @apply break-words bg-white;
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c89a974</samp>

This pull request refactors the border colors of some components and adds border rings to some dropdown menus to use a consistent and contrasted color scheme across the app. It also adds a rule to set the dark mode color for the html element.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c89a974</samp>

> _`border-color` changes_
> _refining the app's design_
> _autumn of refactor_

### WHY
1. Native date pickers have incorrect colors in dark mode. Use `color-scheme: dark` to enable native date pickers to support dark mode.
(It's worth mentioning that `color-scheme: dark` also affects system scrollbars, but @Innei has already fixed the scrollbar style at https://github.com/Crossbell-Box/xLog/pull/332, which is also a great way to fix it.
![Snipaste_2023-04-14_00-30-38](https://user-images.githubusercontent.com/18638914/231836229-4067b402-b191-4caf-84a5-57d94839e9e7.png)
![Snipaste_2023-04-14_00-32-07](https://user-images.githubusercontent.com/18638914/231836270-d177c2da-1ff4-4fe3-820b-8fb915a4572a.png)
2. In dark mode, it's difficult to distinguish the boundary between float cards and the background easily. Add borders to these elements to enhance readability.
![Snipaste_2023-04-14_00-24-05](https://user-images.githubusercontent.com/18638914/231836828-92fceeb1-ba5b-4c8b-b99b-d7b7eb46d804.png)
![Snipaste_2023-04-14_00-24-27](https://user-images.githubusercontent.com/18638914/231836850-01bb6d25-db1d-4a80-99c3-18aae501439d.png)

![Snipaste_2023-04-14_00-54-08](https://user-images.githubusercontent.com/18638914/231836991-5f50857f-47c2-4e73-baad-38db7245c033.png)
![Snipaste_2023-04-14_00-56-23](https://user-images.githubusercontent.com/18638914/231837008-24429819-2f3f-4175-9865-935fcee052c5.png)

![Snipaste_2023-04-14_00-38-13](https://user-images.githubusercontent.com/18638914/231837062-c21a6d58-88fb-4f4c-a1a6-414f44bf391c.png)
![Snipaste_2023-04-14_01-23-39](https://user-images.githubusercontent.com/18638914/231837080-85c31e0b-ec15-4523-a123-a39d2eee6533.png)

![Snipaste_2023-04-14_00-47-34](https://user-images.githubusercontent.com/18638914/231837106-95bd5de2-2f91-4622-b7fd-3da35cd2d144.png)
![Snipaste_2023-04-14_00-47-21](https://user-images.githubusercontent.com/18638914/231837122-0441bd6b-a792-4a9a-a08b-cf5279ac3ef0.png)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c89a974</samp>

* Refactor the border color of `CharacterCard` and `ConnectButton` components to use a custom color instead of the default ([link](https://github.com/Crossbell-Box/xLog/pull/333/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cL54-R54), [link](https://github.com/Crossbell-Box/xLog/pull/333/files?diff=unified&w=0#diff-bcff1bcc3cdc6f01659817ebd75808cbbca143eeed52b41ab365fbba64b491f6L281-R281))
* Add a border ring to the dropdown menus of `PagesManagerMenu` and `SiteHeader` components to improve contrast and visibility ([link](https://github.com/Crossbell-Box/xLog/pull/333/files?diff=unified&w=0#diff-150ba7f34fc715eaad916a1a14891f4a2f6621ecb5d5f0f93cbb10e898710950L169-R169), [link](https://github.com/Crossbell-Box/xLog/pull/333/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL262-R262))
* Support dark mode feature by setting the color scheme to dark for the html element in `tailwind.css` when enabled ([link](https://github.com/Crossbell-Box/xLog/pull/333/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R24-R27))
