### PR TITLE
fix: wrong site link in dev mode

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -17,9 +17,13 @@ export const getSiteLink = ({
     return `https://${domain}`
   }
   if (noProtocol) {
-    return `${subdomain}.${OUR_DOMAIN}`
+    return IS_PROD
+      ? `${subdomain}.${OUR_DOMAIN}`
+      : `${OUR_DOMAIN}/_site/${subdomain}`
   }
-  return `${IS_PROD ? "https" : "http"}://${subdomain}.${OUR_DOMAIN}`
+  return IS_PROD
+    ? `https://${subdomain}.${OUR_DOMAIN}`
+    : `http://${OUR_DOMAIN}/_site/${subdomain}`
 }
 
 export const getNoteSlug = (note: NoteEntity) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0f3d8b</samp>

Updated `getSiteLink` function to handle different environments and options. This improves the compatibility and usability of the function for both production and development servers.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c0f3d8b</samp>

> _`getSiteLink` adapts_
> _to environment and option_
> _like a winter tree_

### WHY
The site link is incorrect in dev mode
![Snipaste_2023-04-14_01-42-32](https://user-images.githubusercontent.com/18638914/231843113-8dd4b462-58b2-4cfa-bd69-be32c4d745cc.png)
![Snipaste_2023-04-14_01-46-22](https://user-images.githubusercontent.com/18638914/231843131-4b233ba9-04e8-4319-acd4-7949e0cfc58f.png)

After:
![Snipaste_2023-04-14_01-49-17](https://user-images.githubusercontent.com/18638914/231843183-b3e66dca-d633-417b-9058-bd8672961dd9.png)
![Snipaste_2023-04-14_01-49-01](https://user-images.githubusercontent.com/18638914/231843211-fd43548c-3ed3-4810-a6cd-9c54a9233d5e.png)


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0f3d8b</samp>

*  Modify `getSiteLink` function to return different URLs for production and development environments ([link](https://github.com/Crossbell-Box/xLog/pull/334/files?diff=unified&w=0#diff-26999e6f9a7fac03a622245890c5bb7f2d49a102fc8b4aaed94001b7be8d7fb3L20-R26))
