### PR TITLE
More consistent style for code blocks in dark mode

### DIFF
--- a/src/css/prism-dark.css
+++ b/src/css/prism-dark.css
@@ -79,3 +79,10 @@ code {
 .token.inserted {
   color: green;
 }
+
+@media (prefers-color-scheme:dark) {
+  code, pre {
+    background: none;
+    color: unset;
+  }
+}

--- a/src/css/prose.css
+++ b/src/css/prose.css
@@ -188,3 +188,9 @@
 .xlog-comment .prose p {
   @apply my-1;
 }
+
+@media (prefers-color-scheme:dark) {
+  .prose pre {
+    border: 1px solid;
+  }
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aa7ee54</samp>

This pull request adds media queries to `prism-dark.css` and `prose.css` to improve the appearance of code blocks for users who prefer a dark color scheme. It removes unnecessary styles from the code elements and adds a border to the pre elements.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aa7ee54</samp>

> _`prism-dark.css`_
> _Adjusts code blocks for night owls_
> _Winter solstice theme_

Provide a more consistent style for code blocks in dark mode.

### WHY
<img width="750" alt="image" src="https://user-images.githubusercontent.com/74791570/231898602-ecd4c4bf-f656-4f3d-b265-113ffbebed33.png">

<img width="744" alt="image" src="https://user-images.githubusercontent.com/74791570/231898542-7a929300-d0d2-433e-8c62-3c67c655a5c2.png">

The reason for providing a more constant style for code blocks in dark mode is to avoid them being too visually distracting or excessively bright for users. By ensuring that code blocks are cohesive with other elements on the page and don't stand out too much, users can have a more comfortable and seamless viewing experience. This can help prevent eye strain, fatigue, or discomfort that may arise from looking at overly bright or contrasting elements for extended periods of time.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aa7ee54</samp>

*  Add media queries for dark mode preference to `prism-dark.css` and `prose.css` ([link](https://github.com/Crossbell-Box/xLog/pull/335/files?diff=unified&w=0#diff-10295549cb12421ef03195aef40deb8d73809bb33337f4d99022dc6e64242ec3R82-R88), [link](https://github.com/Crossbell-Box/xLog/pull/335/files?diff=unified&w=0#diff-ee2b13850d8f82fbae8bc911e0261cca67f922e871d05a76f20e78381e26e7bbR191-R196))

I don't have much experience with CSS in JS and I'm not familiar with the structure of the repository, so feel free to implement it in any other way.