### PR TITLE
fix: buffer article content during IME composition

### DIFF
--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -44,7 +44,6 @@ import { serverSidePropsHandler } from "~/lib/server-side-props"
 import { getDefaultSlug } from "~/lib/helpers"
 import { useMobileLayout } from "~/hooks/useMobileLayout"
 import { OptionsButton } from "~/components/dashboard/OptionsButton"
-import { useDebounce } from "@crossbell/util-hooks"
 
 export const getServerSideProps: GetServerSideProps = serverSidePropsHandler(
   async (ctx) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26f9b41</samp>

Fixed a bug in the editor page for IME users and improved the value update logic. The change affects the file `src/pages/dashboard/[subdomain]/editor.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 26f9b41</samp>

> _Editor bug fixed_
> _`onChange` checks composition_
> _Autumn leaves fall slow_

### WHY
In Firefox, when users type using an input method editor (IME), the cursor returns to the beginning of the editor.
fix #323

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26f9b41</samp>

* Import `ViewUpdate` type to use as parameter for `onChange` callback ([link](https://github.com/Crossbell-Box/xLog/pull/339/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L32-R32))
* Fix bug with IME input by checking composition state and using ref and `requestAnimationFrame` to update value ([link](https://github.com/Crossbell-Box/xLog/pull/339/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L363-R381))
* Remove unnecessary empty line ([link](https://github.com/Crossbell-Box/xLog/pull/339/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R346))
