### PR TITLE
fix: dark mode cannot switch correctly

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -18,7 +18,7 @@ interface DarkModeConfig {
   classNameDark?: string // A className to set "dark mode". Default = "dark-mode".
   classNameLight?: string // A className to set "light mode". Default = "light-mode".
   element?: HTMLElement | undefined | null // The element to apply the className. Default = `document.body`
-  storageKey?: string // Specify the `localStorage` key. Default = "darkMode". Sewt to `null` to disable persistent storage.
+  storageKey?: string // Specify the `localStorage` key. Default = "darkMode". set to `undefined` to disable persistent storage.
 }
 
 const useDarkMode = (
@@ -37,11 +37,11 @@ const useDarkMode = (
   useEffect(() => {
     const presentedDarkMode = storageKey
       ? isServerSide()
-        ? null
-        : getStorage(storageKey) || null
-      : null
+        ? undefined
+        : getStorage(storageKey)
+      : undefined
 
-    if (presentedDarkMode !== null) {
+    if (presentedDarkMode !== undefined) {
       if (presentedDarkMode === "true") {
         setDarkMode(true)
       } else if (presentedDarkMode === "false") {
@@ -55,14 +55,14 @@ const useDarkMode = (
   useEffect(() => {
     const handler = (e: MediaQueryListEvent) => {
       const storageValue = getStorage(storageKey || "darkMode")
-      if (storageValue === null) {
+      if (storageValue === undefined) {
         setDarkMode(e.matches)
       }
     }
 
     const focusHandler = () => {
       const storageValue = getStorage(storageKey || "darkMode")
-      if (storageValue === null) {
+      if (storageValue === undefined) {
         setDarkMode(window.matchMedia("(prefers-color-scheme: dark)").matches)
       }
     }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5d41e3d</samp>

Improved dark mode functionality in `useDarkMode` hook. Changed default values of `storageKey` and `presentedDarkMode` to `undefined` in `src/hooks/useDarkMode.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5d41e3d</samp>

> _In the shadows of the night, we `useDarkMode` to fight_
> _No `null` values can deceive us, we set them to `undefined`_
> _We don't need persistent storage, we trust our own courage_
> _We are the dark mode warriors, we defy the light of the sun_

### WHY
<!-- author to complete -->
In c27b06c4e2c6cc6dc501871fb6c3443581fc9a0d commit, getStorage will return undefined instead of null, but we used null for judgment, which caused the failure of night mode switching.

https://user-images.githubusercontent.com/89030875/232041812-3d75fe97-f80d-4a41-8c48-4cba87350326.mov

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5d41e3d</samp>

*  Change the default value of `storageKey` from `null` to `undefined` in the `DarkModeConfig` interface to avoid confusion and bugs with `localStorage` methods ([link](https://github.com/Crossbell-Box/xLog/pull/340/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L21-R21))
*  Change the default value of `presentedDarkMode` from `null` to `undefined` and simplify the condition check for it in the `useDarkMode` hook ([link](https://github.com/Crossbell-Box/xLog/pull/340/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L40-R44))
*  Change the condition check for `storageValue` from `null` to `undefined` in the `handler` and `focusHandler` functions and update the `darkMode` state accordingly based on the media query and window focus events ([link](https://github.com/Crossbell-Box/xLog/pull/340/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L58-R58), [link](https://github.com/Crossbell-Box/xLog/pull/340/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L65-R65))
