### PR TITLE
feat(darkmode): optimize code and add dark mode switch button

### DIFF
--- a/src/components/common/DarkModeSwitch.tsx
+++ b/src/components/common/DarkModeSwitch.tsx
@@ -1,0 +1,29 @@
+import { Switch } from "@headlessui/react"
+import { useDarkModeSwitch, useIsDark } from "~/hooks/useDarkMode"
+
+export const DarkModeSwitch = () => {
+  const toggle = useDarkModeSwitch()
+  const isDark = useIsDark()
+  return (
+    <Switch
+      checked={isDark}
+      onChange={toggle}
+      className={`${
+        isDark ? "bg-accent" : "bg-gray-200"
+      } ml-5 relative inline-flex h-6 w-11 items-center rounded-full text-base dark:text-always-gray-200 text-always-gray-700`}
+    >
+      <span className="sr-only">Switch Dark Mode</span>
+      <span
+        className={`${
+          isDark ? "translate-x-6" : "translate-x-1"
+        } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+      />
+
+      {isDark ? (
+        <i className="i-mingcute:moon-line translate-x-2 scale-75" />
+      ) : (
+        <i className="i-mingcute:sun-line scale-75 -translate-x-3" />
+      )}
+    </Switch>
+  )
+}

--- a/src/components/common/Monaco/index.tsx
+++ b/src/components/common/Monaco/index.tsx
@@ -1,9 +1,9 @@
 import Editor, { EditorProps } from "@monaco-editor/react"
 import { useMonacoTheme } from "./use-theme"
-import { useMediaStore } from "~/hooks/useDarkMode"
+import { useIsDark } from "~/hooks/useDarkMode"
 
 export function MonacoEditor(props: EditorProps) {
-  const isDark = useMediaStore((state) => state.isDark)
+  const isDark = useIsDark()
   useMonacoTheme(isDark)
 
   return (

--- a/src/components/common/Monaco/use-theme.ts
+++ b/src/components/common/Monaco/use-theme.ts
@@ -1,6 +1,5 @@
 import { useMonaco } from "@monaco-editor/react"
 import { useEffect } from "react"
-import { useMediaStore } from "~/hooks/useDarkMode"
 import Dark from "./theme/dark.json"
 import Light from "./theme/light.json"
 

--- a/src/components/main/MainLayout.tsx
+++ b/src/components/main/MainLayout.tsx
@@ -14,6 +14,7 @@ import { Logo } from "~/components/common/Logo"
 import { useRouter } from "next/router"
 import { cn } from "~/lib/utils"
 import { Image } from "../ui/Image"
+import { DarkModeSwitch } from "../common/DarkModeSwitch"
 
 const tabs = [
   {
@@ -103,16 +104,19 @@ export function MainLayout({
               </UniLink>
             )}
           </span>
-          <span className="align-middle">
-            &copy;{" "}
-            <UniLink
-              href={getSiteLink({
-                subdomain: "xlog",
-              })}
-              className="hover:text-accent"
-            >
-              {APP_NAME}
-            </UniLink>
+          <span className="inline-flex items-center space-x-4">
+            <DarkModeSwitch />
+            <span>
+              &copy;{" "}
+              <UniLink
+                href={getSiteLink({
+                  subdomain: "xlog",
+                })}
+                className="hover:text-accent"
+              >
+                {APP_NAME}
+              </UniLink>
+            </span>
           </span>
         </div>
       </footer>

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -2,11 +2,11 @@ import { APP_NAME, SITE_URL } from "~/lib/env"
 import { UniLink } from "../ui/UniLink"
 import { Profile, Note } from "~/lib/types"
 import Script from "next/script"
-import Image from "next/image"
 import { Platform } from "~/components/site/Platform"
 import { Trans } from "next-i18next"
 import { Logo } from "~/components/common/Logo"
 import { useEffect, useState } from "react"
+import { DarkModeSwitch } from "../common/DarkModeSwitch"
 
 export const SiteFooter: React.FC<{
   site?: Profile | null
@@ -61,6 +61,7 @@ export const SiteFooter: React.FC<{
               ))}
             </div>
           )}
+          <DarkModeSwitch />
         </div>
       </footer>
       {site?.ga && (

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -22,7 +22,7 @@ import { Tooltip } from "~/components/ui/Tooltip"
 import { PatronButton } from "~/components/common/PatronButton"
 import { Modal } from "~/components/ui/Modal"
 import { SearchInput } from "~/components/common/SearchInput"
-import { useMediaStore } from "~/hooks/useDarkMode"
+import { useIsDark } from "~/hooks/useDarkMode"
 
 type HeaderLinkType = {
   icon?: React.ReactNode
@@ -133,7 +133,7 @@ export const SiteHeader: React.FC<{
   const avatarRef = useRef<HTMLImageElement>(null)
   const bannerRef = useRef<HTMLImageElement | HTMLVideoElement>(null)
 
-  const isDark = useMediaStore((state) => state.isDark)
+  const isDark = useIsDark()
   const [averageColor, setAverageColor] = useState<string>()
   const [autoHoverColor, setAutoHoverColor] = useState<string>()
   const [autoThemeColor, setAutoThemeColor] = useState<string>()

--- a/src/components/ui/Editor.tsx
+++ b/src/components/ui/Editor.tsx
@@ -10,7 +10,7 @@ import {
   codemirrorReconfigureExtension,
   useCodeMirrorAutoToggleTheme,
 } from "~/hooks/useCodemirrorTheme"
-import { useMediaStore } from "~/hooks/useDarkMode"
+import { useIsDark } from "~/hooks/useDarkMode"
 
 export const Editor: React.FC<{
   value: string
@@ -33,7 +33,7 @@ export const Editor: React.FC<{
   const [extensions, setExtensions] = useState<any>([])
   const isMobileLayout = useMobileLayout()
   const [editor, setCmEditor] = useState<EditorView | null>(null)
-  const isDark = useMediaStore((state) => state.isDark)
+  const isDark = useIsDark()
   useCodeMirrorAutoToggleTheme(editor, isDark)
 
   useEffect(() => {

--- a/src/components/ui/Mermaid.tsx
+++ b/src/components/ui/Mermaid.tsx
@@ -1,6 +1,6 @@
 import { FC, useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
-import { useMediaStore } from "~/hooks/useDarkMode"
+import { useIsDark } from "~/hooks/useDarkMode"
 import { useIsUnmounted } from "~/hooks/useLifecycle"
 import { nanoid } from "nanoid"
 
@@ -12,7 +12,7 @@ export const Mermaid: FC<{
   const [svg, setSvg] = useState("")
   const isUnmounted = useIsUnmounted()
 
-  const isDark = useMediaStore((state) => state.isDark)
+  const isDark = useIsDark()
 
   useEffect(() => {
     import("mermaid").then(async (mo) => {

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -14,8 +14,6 @@ const useMediaStore = create<IMediaStore>(() => {
   }
 })
 
-export const useIsDark = () => useMediaStore((state) => state.isDark)
-
 const isServerSide = () => typeof window === "undefined"
 
 interface DarkModeConfig {
@@ -130,7 +128,7 @@ const mockElement = {
 }
 const darkModeKey = "darkMode"
 export const useDarkMode = () => {
-  const { toggle, value } = useDarkModeInternal(undefined, {
+  const { toggle, value } = useDarkModeInternal(getStorage(darkModeKey), {
     classNameDark: "dark",
     classNameLight: "light",
     storageKey: darkModeKey,
@@ -166,4 +164,10 @@ export const useDarkMode = () => {
     toggle,
     value,
   }
+}
+
+export const useIsDark = () => useMediaStore((state) => state.isDark)
+
+export const useDarkModeSwitch = () => {
+  return useMediaStore((state) => state.toggle)
 }

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -56,10 +56,11 @@ const useDarkModeInternal = (
   }, [storageKey])
 
   useEffect(() => {
-    const handler = (e: Pick<MediaQueryListEvent, "matches">) => {
+    const handler = (e: MediaQueryListEvent) => {
       const storageValue = getStorage(storageKey)
       const parseStorageValueAsBool = storageValue === "true"
       setDarkMode(e.matches)
+
       // reset dark mode, follow system
       if (parseStorageValueAsBool === e.matches) {
         delStorage(storageKey)
@@ -67,9 +68,11 @@ const useDarkModeInternal = (
     }
 
     const focusHandler = () => {
-      handler({
-        matches: window.matchMedia("(prefers-color-scheme: dark)").matches,
-      })
+      const storageValue = getStorage(storageKey)
+      // if back to page and not storage color mode, switch to follow system
+      if (storageValue === undefined) {
+        setDarkMode(window.matchMedia("(prefers-color-scheme: dark)").matches)
+      }
     }
 
     window.addEventListener("focus", focusHandler)

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -16,7 +16,8 @@ export const getStorage = (key: string) => {
 }
 
 export const setStorage = (key: string, value: any) => {
-  data[key] = Object.assign({}, data[key], value)
+  data[key] =
+    typeof value !== "object" ? value : Object.assign({}, data[key], value)
   localStorage.setItem(namespace, JSON.stringify(data))
 }
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -20,7 +20,7 @@ import { toGateway } from "~/lib/ipfs-parser"
 import { createIDBPersister } from "~/lib/persister.client"
 import { urlComposer } from "~/lib/url-composer"
 import { AppPropsWithLayout } from "types/next"
-import { useMediaToggle } from "~/hooks/useDarkMode"
+import { useDarkMode } from "~/hooks/useDarkMode"
 
 Network.setIpfsGateway(IPFS_GATEWAY)
 
@@ -39,7 +39,7 @@ const persister = createIDBPersister()
 function MyApp({ Component, pageProps }: AppPropsWithLayout) {
   const getLayout = Component.getLayout ?? ((page) => page)
 
-  useMediaToggle()
+  useDarkMode()
   return (
     <WagmiConfig client={wagmiClient}>
       <PersistQueryClientProvider

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,7 @@ const alwaysColor = require("tailwindcss/colors")
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ["./src/**/*.tsx"],
+  darkMode: ["class", "html.dark"],
   theme: {
     colors: twColors,
     extend: {


### PR DESCRIPTION
Signed-off-by: Innei <tukon479@gmail.com>
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19428b8</samp>

This pull request adds a dark mode feature to the xLog application. It introduces a `DarkModeSwitch` component that allows users to toggle between light and dark themes. It also refactors the dark mode logic and state management using custom hooks and zustand. It updates various components to use the new hooks and simplify the dark mode detection and theme application.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 19428b8</samp>

> _In the darkness of the night, we seek the light_
> _We use the `DarkModeSwitch` to change our sight_
> _We simplify the logic with the `useIsDark` hook_
> _We store our preference with the `setStorage` book_

### WHY
Improve dark mode UX. Fix storage bug if value not is object.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19428b8</samp>

*  Add a new component `DarkModeSwitch` that renders a switch button to toggle between dark and light mode ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-a5cebf01f5a3695ff1f69ee076704d693ad21263bdfa158ed24867e8beba2bd9R1-R29))
*  Replace the import and use of `useMediaStore` with `useIsDark` in several components that need to access the current dark mode state (`SiteHeader`, `Editor`, `MonacoEditor`, `Mermaid`) ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-313398368032159ff3bd9267c92e006c2fd2c59213b83501d6c56c41af44445bL3-R6), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL25-R25), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL136-R136), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-72e77d08bb831167bf29c18556d9e2916a5fa2dac8806ac0bf432e8c535d15a7L13-R13), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-72e77d08bb831167bf29c18556d9e2916a5fa2dac8806ac0bf432e8c535d15a7L36-R36), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-41171ef172b5b1197709973536f58ca087291a8c881fe5333cf1c93980fd2541L3-R3), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-41171ef172b5b1197709973536f58ca087291a8c881fe5333cf1c93980fd2541L15-R15))
*  Remove the unused import of `useMediaStore` from the `use-theme` module ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-ba9ca1a0b177c537be6abdb951219bbc783a3b7c8196cc35270d12e1664ffc73L3))
*  Add the `DarkModeSwitch` component to the footer of the `MainLayout` and `SiteFooter` components ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-fc489ae2d39f9bcc45ec717ebe1feac8e43558c7a2686e944f5698cd03d4be4aR17), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-fc489ae2d39f9bcc45ec717ebe1feac8e43558c7a2686e944f5698cd03d4be4aL106-R119), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-765d257cdb9e99b90862bdf509d92d60910659262e97a25f78e2c48a44847bcfL5-R9), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-765d257cdb9e99b90862bdf509d92d60910659262e97a25f78e2c48a44847bcfR64))
*  Modify the `useMediaStore` zustand store to include a `toggle` function that switches the dark mode state ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L1-R13))
*  Rename the `useDarkMode` hook to `useDarkModeInternal` and the `useMediaToggle` hook to `useDarkMode` ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L24-R26), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L128-R131))
*  Assign the `toggle` function from the `useDarkModeInternal` hook to the `useMediaStore` state once ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L137-R149))
*  Add two new hooks: `useIsDark` and `useDarkModeSwitch` that return the current dark mode state and the `toggle` function from the `useMediaStore` state ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0R168-R173))
*  Modify the `setStorage` function to handle non-object values ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-69a5c2bf4322fa6dd3eb08beb1de557902ba44c75a00910bb25e2e46b6f35dc3L19-R20))
*  Replace the import and use of `useMediaToggle` with `useDarkMode` in the `_app` page ([link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-88a36bc7a53bfa58c6f451464798d631d785160dfacfdaf9479be7a0b1d7e5e5L23-R23), [link](https://github.com/Crossbell-Box/xLog/pull/341/files?diff=unified&w=0#diff-88a36bc7a53bfa58c6f451464798d631d785160dfacfdaf9479be7a0b1d7e5e5L42-R42))
