### PR TITLE
feat: share to twitter after post and add preview on menu item

### DIFF
--- a/src/components/dashboard/PagesManagerMenu.tsx
+++ b/src/components/dashboard/PagesManagerMenu.tsx
@@ -9,6 +9,8 @@ import { useQueryClient } from "@tanstack/react-query"
 import { APP_NAME } from "~/lib/env"
 import { useTranslation } from "next-i18next"
 import { useGetState } from "~/hooks/useGetState"
+import { getNoteSlugFromNote, getSiteLink } from "~/lib/helpers"
+import { useGetSite } from "~/queries/site"
 
 const usePageEditLink = (page: { id: string }, isPost: boolean) => {
   const router = useRouter()
@@ -19,6 +21,11 @@ const usePageEditLink = (page: { id: string }, isPost: boolean) => {
   }`
 }
 
+interface Item {
+  text: string
+  icon: JSX.Element
+  onClick: () => void
+}
 export const PagesManagerMenu: FC<{
   isPost: boolean
   page: Note
@@ -72,7 +79,9 @@ export const PagesManagerMenu: FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [createOrUpdatePage.isSuccess, createOrUpdatePage.isError])
 
-  const items = [
+  const site = useGetSite(subdomain)
+
+  const items: Item[] = [
     {
       text: "Edit",
       icon: <span className="i-mingcute:edit-line inline-block"></span>,
@@ -127,6 +136,32 @@ export const PagesManagerMenu: FC<{
             })
           }
         }
+      },
+    },
+    {
+      text: "Preview",
+      icon: <span className="i-mingcute:eye-line inline-block"></span>,
+      onClick() {
+        const slug = getNoteSlugFromNote(page)
+        if (!slug) return
+        window.open(`/_site/${subdomain}/${slug}`)
+      },
+    },
+    {
+      text: "Share to Twitter",
+      icon: <span className="i-mingcute:twitter-line inline-block"></span>,
+      onClick() {
+        const slug = getNoteSlugFromNote(page)
+        if (!slug) return
+
+        window.open(
+          `https://twitter.com/intent/tweet?url=${getSiteLink({
+            subdomain,
+            domain: site.data?.custom_domain,
+          })}/${encodeURIComponent(slug)}&via=_xLog&text=${encodeURIComponent(
+            `Read my new post - ${page.title}`,
+          )}`,
+        )
       },
     },
     {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -3,6 +3,8 @@ import { NoteEntity } from "crossbell.js"
 import { IS_PROD } from "./constants"
 import { OUR_DOMAIN } from "./env"
 import pinyin from "pinyin"
+import { Page } from "./types"
+import { Note } from "unidata.js"
 
 export const getSiteLink = ({
   domain,
@@ -32,6 +34,9 @@ export const getNoteSlug = (note: NoteEntity) => {
   )?.toLowerCase?.()
 }
 
+export const getNoteSlugFromNote = (page: Note) => {
+  return page.attributes?.find(($) => $.trait_type === "xlog_slug")?.value
+}
 export const getDefaultSlug = (title: string, id?: string) => {
   let generated =
     pinyin(title as string, {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -3,7 +3,6 @@ import { NoteEntity } from "crossbell.js"
 import { IS_PROD } from "./constants"
 import { OUR_DOMAIN } from "./env"
 import pinyin from "pinyin"
-import { Page } from "./types"
 import { Note } from "unidata.js"
 
 export const getSiteLink = ({


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9c2063f</samp>

This pull request adds the ability to preview and share pages from the dashboard menu. It modifies the `PagesManagerMenu` component and adds a helper function to `src/lib/helpers.ts` to generate page URLs from notes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9c2063f</samp>

> _Preview and share pages_
> _`PagesManagerMenu` grows_
> _Autumn leaves fall fast_

### WHY
<img width="592" alt="image" src="https://user-images.githubusercontent.com/41265413/232105129-2b5698d7-f78b-4cfd-8ad7-79e0328c91e1.png">


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9c2063f</samp>

* Import helper functions and types for generating page URLs and tweet texts ([link](https://github.com/Crossbell-Box/xLog/pull/342/files?diff=unified&w=0#diff-150ba7f34fc715eaad916a1a14891f4a2f6621ecb5d5f0f93cbb10e898710950R12-R13), [link](https://github.com/Crossbell-Box/xLog/pull/342/files?diff=unified&w=0#diff-26999e6f9a7fac03a622245890c5bb7f2d49a102fc8b4aaed94001b7be8d7fb3R6-R7))
* Define `Item` interface for menu items and use `useGetSite` hook to fetch site data ([link](https://github.com/Crossbell-Box/xLog/pull/342/files?diff=unified&w=0#diff-150ba7f34fc715eaad916a1a14891f4a2f6621ecb5d5f0f93cbb10e898710950R24-R28), [link](https://github.com/Crossbell-Box/xLog/pull/342/files?diff=unified&w=0#diff-150ba7f34fc715eaad916a1a14891f4a2f6621ecb5d5f0f93cbb10e898710950L75-R84))
* Add "Preview" and "Share to Twitter" menu items that use helper functions to open new windows ([link](https://github.com/Crossbell-Box/xLog/pull/342/files?diff=unified&w=0#diff-150ba7f34fc715eaad916a1a14891f4a2f6621ecb5d5f0f93cbb10e898710950R142-R167))
