### PR TITLE
fix: The tooltip in the comment is hidden

### DIFF
--- a/src/css/prose.css
+++ b/src/css/prose.css
@@ -178,7 +178,7 @@
 }
 
 .xlog-comment .prose {
-  @apply leading-normal text-[15px];
+  @apply leading-normal text-[15px] overflow-visible;
 }
 
 .xlog-comment .prose blockquote {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75a46f0</samp>

Added a CSS class to fix comment overflow bug. This change affects the `prose.css` file and resolves issue #12.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 75a46f0</samp>

> _`overflow-visible`_
> _fixes long comment bug_
> _autumn leaves uncut_

### WHY
The tooltip in the comments may be concealed by the 'overflow: hidden' property of the '.prose' class when it exceeds the bounds of the comment area.

评论里的tooltip如果超出评论区域会被 `.prose` class 上的 `overflow: hidden`出现遮挡

Before:
<img width="863" alt="image" src="https://user-images.githubusercontent.com/15699954/232209800-404dc01c-a16c-41ba-abb7-396790ef8ef9.png">

After:
<img width="828" alt="image" src="https://user-images.githubusercontent.com/15699954/232209850-d16a2cd2-7d0b-459b-902f-3f4d68b4f7d4.png">



### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75a46f0</samp>

*  Add `overflow-visible` class to `.xlog-comment .prose` selector to fix comment truncation bug ([link](https://github.com/Crossbell-Box/xLog/pull/344/files?diff=unified&w=0#diff-ee2b13850d8f82fbae8bc911e0261cca67f922e871d05a76f20e78381e26e7bbL181-R181))
