### PR TITLE
fix: character list text overflow

### DIFF
--- a/src/components/common/CharacterList.tsx
+++ b/src/components/common/CharacterList.tsx
@@ -47,7 +47,7 @@ export const CharacterList: React.FC<{
                       href={getSiteLink({
                         subdomain: character?.handle,
                       })}
-                      className="flex items-center space-x-2 text-sm"
+                      className="flex items-center space-x-2 text-sm min-w-0"
                     >
                       <CharacterFloatCard siteId={character?.handle}>
                         <Avatar


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d36ee1b</samp>

Fixed character name overflow in `CharacterList` component. Added `min-w-0` to `className` of `Link` in `src/components/common/CharacterList.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d36ee1b</samp>

> _`Link` gets `min-w-0`_
> _No more overflowing names_
> _Autumn leaves fall neat_

### WHY
<img width="503" alt="Xnip2023-04-16_14-14-07" src="https://user-images.githubusercontent.com/41265413/232276160-4c65a145-2351-4519-bca0-90905430cef5.png">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d36ee1b</samp>

*  Prevent character name overflow in `CharacterList` component by adding `min-w-0` to `className` attribute of `Link` component ([link](https://github.com/Crossbell-Box/xLog/pull/350/files?diff=unified&w=0#diff-a409ba5ed93668907a24feb7c7ebfd9866fde92d6bd14a811c66638e19594c09L50-R50))
