### PR TITLE
feat: make multiple pages switch to dark mode together

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -18,9 +18,9 @@ const useMediaStore = create<IMediaStore>(() => {
 const isServerSide = () => typeof window === "undefined"
 
 interface DarkModeConfig {
-  classNameDark?: string // A className to set "dark mode". Default = "dark-mode".
-  classNameLight?: string // A className to set "light mode". Default = "light-mode".
-  element?: HTMLElement | undefined | null // The element to apply the className. Default = `document.body`
+  classNameDark?: string // A className to set "dark mode". Default = "dark".
+  classNameLight?: string // A className to set "light mode". Default = "light".
+  element?: HTMLElement | undefined | null // The element to apply the className. Default = `document.body`.
   storageKey?: string // Specify the `localStorage` key. Default = "darkMode". set to `undefined` to disable persistent storage.
 }
 const darkModeKey = "darkMode"
@@ -67,21 +67,28 @@ const useDarkModeInternal = (
       }
     }
 
-    const focusHandler = () => {
-      const storageValue = getStorage(storageKey)
-      // if back to page and not storage color mode, switch to follow system
+    const storageHandler = () => {
+      const storageValue = getStorage(storageKey, true)
+      // if not storage color mode, switch to follow system
       if (storageValue === undefined) {
         setDarkMode(window.matchMedia("(prefers-color-scheme: dark)").matches)
+      } else {
+        // make multiple pages to switch to dark mode together.
+        if (storageValue === "true") {
+          setDarkMode(true)
+        } else if (storageValue === "false") {
+          setDarkMode(false)
+        }
       }
     }
 
-    window.addEventListener("focus", focusHandler)
+    window.addEventListener("storage", storageHandler)
     window
       .matchMedia("(prefers-color-scheme: dark)")
       .addEventListener("change", handler)
 
     return () => {
-      window.removeEventListener("focus", focusHandler)
+      window.removeEventListener("storage", storageHandler)
       window
         .matchMedia("(prefers-color-scheme: dark)")
         .removeEventListener("change", handler)

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -11,7 +11,12 @@ export const getKeys = (key: string) => {
   return Object.keys(data).filter((k) => k.startsWith(key))
 }
 
-export const getStorage = (key: string) => {
+export const getStorage = (key: string, noCache?: boolean) => {
+  if (noCache) {
+    try {
+      data = JSON.parse(localStorage.getItem(namespace) || "{}")
+    } catch (error) {}
+  }
   return data[key]
 }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 143edfb</samp>

Improved the functionality and compatibility of the dark mode switch in `useDarkMode` hook. Added a `noCache` option to `getStorage` function in `storage` library.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 143edfb</samp>

> _Darkness falls on every tab_
> _We need to get the latest data_
> _No cache can stop our storageHandler_
> _We switch the mode with a new listener_

### WHY
<!-- author to complete -->
make multiple pages switch to dark mode together.

Before:

https://user-images.githubusercontent.com/89030875/232315196-a3a781df-be01-4070-99ed-81770b5fc820.mov

After:

https://user-images.githubusercontent.com/89030875/232315471-a041b6fd-dc22-4305-b807-8ce216384369.mov


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 143edfb</samp>

*  Simplify dark mode and light mode class names to avoid conflicts with other CSS frameworks ([link](https://github.com/Crossbell-Box/xLog/pull/353/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L21-R23))
*  Replace focus event listener with storage event listener to sync dark mode preference across tabs and windows ([link](https://github.com/Crossbell-Box/xLog/pull/353/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L70-R85), [link](https://github.com/Crossbell-Box/xLog/pull/353/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L84-R91))
*  Add noCache parameter to getStorage function to allow refreshing data from localStorage when storage event is triggered ([link](https://github.com/Crossbell-Box/xLog/pull/353/files?diff=unified&w=0#diff-69a5c2bf4322fa6dd3eb08beb1de557902ba44c75a00910bb25e2e46b6f35dc3L14-R19))
*  Update useEffect hook to remove storageHandler function when component unmounts ([link](https://github.com/Crossbell-Box/xLog/pull/353/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L84-R91))
