### PR TITLE
feat: optimize print mode (export pdf) preview layout

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,8 @@
+declare module "react" {
+  export interface HTMLAttributes<T> extends AriaAttributes, DOMAttributes<T> {
+    "data-hide-print"?: boolean
+    "aria-hidden"?: boolean
+  }
+}
+
+export {}

--- a/src/components/common/BlockchainInfo.tsx
+++ b/src/components/common/BlockchainInfo.tsx
@@ -21,6 +21,7 @@ export const BlockchainInfo: React.FC<{
             <Disclosure.Button
               className="flex w-full justify-between items-center rounded-lg px-4 py-2 text-left text-gray-900 hover:bg-hover transition-colors md:rounded-xl"
               aria-label="toggle chain info"
+              data-hide-print
             >
               <span className="flex items-center">
                 <BlockchainIcon className="mr-1" />

--- a/src/components/common/Comment.tsx
+++ b/src/components/common/Comment.tsx
@@ -16,7 +16,11 @@ export const Comment: React.FC<{
   const { t } = useTranslation("common")
 
   return (
-    <div className={cn("xlog-comment comment", className)} id="comments">
+    <div
+      className={cn("xlog-comment comment", className)}
+      id="comments"
+      data-hide-print
+    >
       <div className="xlog-comment-count border-b pb-2 mb-6">
         <span>
           {comments.isLoading

--- a/src/components/common/Reactions.tsx
+++ b/src/components/common/Reactions.tsx
@@ -154,6 +154,7 @@ export const Reactions: React.FC<{
           size === "sm" ? "text-sm space-x-3" : "space-x-6 sm:space-x-10",
           className,
         )}
+        data-hide-print
       >
         <div className={cn("xlog-reactions-like flex items-center sm:mb-0")}>
           <Button

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -4,5 +4,6 @@
 @import "./code.css";
 @import "./prism-dark.css";
 @import "./css-var.css";
+@import "./print.css";
 
 @import url("https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css");

--- a/src/css/print.css
+++ b/src/css/print.css
@@ -1,0 +1,8 @@
+@media print {
+  nav,
+  header,
+  footer,
+  *[data-hide-print] {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c4fed8f</samp>

This pull request adds a `data-hide-print` attribute to some components and imports a `print.css` file to hide irrelevant elements when printing the page. The purpose is to improve the printability of the posts and their main content.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c4fed8f</samp>

> _`data-hide-print`_
> _Hides elements for printing_
> _Like autumn leaves fall_

### WHY
improve export pdf layout

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c4fed8f</samp>

*  Hide irrelevant elements when printing the page by adding a custom attribute `data-hide-print` to the following components: `BlockchainInfo` ([link](https://github.com/Crossbell-Box/xLog/pull/354/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bR24)), `Comment` ([link](https://github.com/Crossbell-Box/xLog/pull/354/files?diff=unified&w=0#diff-e9b67001b60c37c7782487a9f43a1fa474113c4b958b4421e71bb917223226b6L19-R23)), and `Reactions` ([link](https://github.com/Crossbell-Box/xLog/pull/354/files?diff=unified&w=0#diff-9259077a549e042393efb40623569b7924b179af8b5a3259688ea6ff92f94f09R157)).
