### PR TITLE
feat: support image zoom

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "lottie-react": "^2.4.0",
     "mdast-util-to-string": "3.2.0",
     "mdast-util-toc": "6.1.1",
+    "medium-zoom": "1.0.8",
     "mermaid": "10.1.0",
     "nanoid": "4.0.2",
     "next": "13.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,9 @@ dependencies:
   mdast-util-toc:
     specifier: 6.1.1
     version: 6.1.1
+  medium-zoom:
+    specifier: 1.0.8
+    version: 1.0.8
   mermaid:
     specifier: 10.1.0
     version: 10.1.0(react-dom@18.2.0)(react@18.2.0)
@@ -9705,6 +9708,10 @@ packages:
   /mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
     dev: true
+
+  /medium-zoom@1.0.8:
+    resolution: {integrity: sha512-CjFVuFq/IfrdqesAXfg+hzlDKu6A2n80ZIq0Kl9kWjoHh9j1N9Uvk5X0/MmN0hOfm5F9YBswlClhcwnmtwz7gA==}
+    dev: false
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}

--- a/src/components/dashboard/ImportPreview.tsx
+++ b/src/components/dashboard/ImportPreview.tsx
@@ -1,10 +1,8 @@
-import { useEffect, useRef, useState } from "react"
-import useOnClickOutside from "use-onclickoutside"
 import type { NoteMetadata } from "crossbell.js"
-import { PageContent } from "../common/PageContent"
+import { useState } from "react"
 import { useDate } from "~/hooks/useDate"
+import { PageContent } from "../common/PageContent"
 
-import { Button, ButtonGroup } from "../ui/Button"
 import { useTranslation } from "next-i18next"
 
 export const ImportPreview: React.FC<{

--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -9,7 +9,7 @@ export const Avatar: React.FC<
     name?: string | null
     size?: number
     rounded?: boolean
-    imageRef?: React.Ref<HTMLImageElement>
+    imageRef?: React.MutableRefObject<HTMLImageElement>
   } & React.HTMLAttributes<HTMLSpanElement>
 > = ({ images, size, name, className, rounded, imageRef, ...props }) => {
   size = size || 60

--- a/src/components/ui/Image.tsx
+++ b/src/components/ui/Image.tsx
@@ -1,22 +1,70 @@
-import React from "react"
+import React, { useEffect } from "react"
 import { default as NextImage, ImageProps } from "next/image"
 import { toGateway, toIPFS } from "~/lib/ipfs-parser"
+import { useMobileLayout } from "~/hooks/useMobileLayout"
+import { useGetState } from "~/hooks/useGetState"
 
-export const Image: React.FC<
-  {
-    className?: string
-    src?: string
-    width?: number | string
-    height?: number | string
-    "original-src"?: string
-    imageRef?: React.Ref<HTMLImageElement>
-  } & React.HTMLAttributes<HTMLImageElement> &
-    ImageProps
-> = ({ fill, className, alt, src, width, height, imageRef, ...props }) => {
+type TImageProps = {
+  className?: string
+  src?: string
+  width?: number | string
+  height?: number | string
+  "original-src"?: string
+  imageRef?: React.MutableRefObject<HTMLImageElement>
+  zoom?: boolean
+} & React.HTMLAttributes<HTMLImageElement> &
+  ImageProps
+
+export const Image: React.FC<TImageProps> = ({
+  fill,
+  className,
+  alt,
+  src,
+  width,
+  height,
+  imageRef,
+  zoom,
+  ...props
+}) => {
   src = toIPFS(src)
   const [paddingTop, setPaddingTop] = React.useState("0")
   const [autoWidth, setAutoWidth] = React.useState(0)
   const noOptimization = className?.includes("no-optimization")
+  const imageRefInternal = React.useRef<HTMLImageElement>(null)
+
+  const isMobileLayout = useMobileLayout()
+  const getSrc = useGetState(src)
+
+  useEffect(() => {
+    if (!imageRef) return
+    if (!imageRefInternal.current) return
+
+    if (typeof imageRef === "object") {
+      imageRef.current = imageRefInternal.current
+    }
+  }, [imageRef])
+  useEffect(() => {
+    const $image = imageRefInternal.current
+    if (!$image) return
+    if (isMobileLayout) {
+      const clickHandler = () => {
+        window.open(getSrc(), "_blank")
+      }
+      $image.addEventListener("click", clickHandler)
+      return () => {
+        $image.removeEventListener("click", clickHandler)
+      }
+    }
+    if (zoom) {
+      import("medium-zoom").then(({ default: mediumZoom }) => {
+        mediumZoom($image, {
+          margin: 10,
+          background: "rgb(var(--tw-colors-i-white))",
+          scrollOffset: 0,
+        })
+      })
+    }
+  }, [zoom, isMobileLayout])
 
   if (!src) {
     return null
@@ -57,7 +105,7 @@ export const Image: React.FC<
           setAutoWidth(naturalWidth)
         }
       }}
-      ref={imageRef}
+      ref={imageRefInternal}
     />
   ) : (
     <span
@@ -89,9 +137,18 @@ export const Image: React.FC<
               setAutoWidth(naturalWidth)
             }
           }}
-          ref={imageRef}
+          ref={imageRefInternal}
         />
       </span>
+    </span>
+  )
+}
+
+export const ZoomedImage: React.FC<TImageProps> = (props) => {
+  return (
+    <span className="text-center block">
+      {/* eslint-disable-next-line jsx-a11y/alt-text */}
+      <Image {...props} zoom />
     </span>
   )
 }

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -16,7 +16,7 @@ import { rehypeWrapCode } from "./rehype-wrap-code"
 import jsYaml from "js-yaml"
 import rehypeReact from "rehype-react"
 import { createElement, ReactElement } from "react"
-import { Image } from "~/components/ui/Image"
+import { ZoomedImage } from "~/components/ui/Image"
 import remarkDirective from "remark-directive"
 import remarkDirectiveRehype from "remark-directive-rehype"
 import { remarkYoutube } from "./remark-youtube"
@@ -177,7 +177,7 @@ export const renderPageContent = (
       .use(html ? () => (tree: any) => {} : rehypeReact, {
         createElement: createElement,
         components: {
-          img: Image,
+          img: ZoomedImage,
           anchor: Element,
           mention: Mention,
           mermaid: Mermaid,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b445cb</samp>

This pull request adds zooming functionality for images in the markdown editor and renderer using the `medium-zoom` package. It also refactors and enhances the `Image` and `Avatar` components to use references to the `img` elements. Additionally, it improves the code quality and readability of the `ImportPreview` component by removing and reordering imports.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9b445cb</samp>

> _`medium-zoom`_
> _Images come alive in spring_
> _`ZoomedImage` shines_

### WHY

support image zoom, improve image preview ux

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9b445cb</samp>

*  Add zooming feature for images in markdown content ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9R146-R154), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcL19-R19), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcL180-R180))
  - Export `ZoomedImage` component that wraps `Image` component with `zoom` prop enabled in `src/components/ui/Image.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9R146-R154))
  - Import `ZoomedImage` component instead of `Image` component in `src/markdown/index.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcL19-R19))
  - Use `ZoomedImage` component instead of `Image` component for `img` tag in `renderPageContent` function in `src/markdown/index.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcL180-R180))
* Refactor `Image` component in `src/components/ui/Image.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9L1-R68), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9L60-R108), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9L92-R140))
  - Add new features and refactor existing code of `Image` component ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9L1-R68))
  - Replace `imageRef` prop with `imageRefInternal` ref in `NextImage` component and `img` element ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9L60-R108), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-b003930e5d9f1b1d97e2fda73756f8235fa389aa2325769cd3d4362b2c75b6e9L92-R140))
* Change type of `imageRef` prop in `Avatar` component in `src/components/ui/Avatar.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-c76a9998d3c7ee55bf87ec2740e108ad6a8e4ee5c279868232a95516e3230629L12-R12))
* Modify import statements in `ImportPreview` component in `src/components/dashboard/ImportPreview.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-3d08cbea6a39f49dfcc260ff6361d604a11b968e4e8f29b737e5ca314a2b378dL1-R5))
* Add `medium-zoom` package as a dependency in `package.json` and `pnpm-lock.yaml` ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R77), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR154-R156), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9712-R9715))
  - Add `medium-zoom` package as a specifier and a resolution in `pnpm-lock.yaml` for version and integrity ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR154-R156), [link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9712-R9715))
  - Add `medium-zoom` package as a dependency in `package.json` for zooming functionality ([link](https://github.com/Crossbell-Box/xLog/pull/355/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R77))
