### PR TITLE
fix: anchor icon not showing

### DIFF
--- a/src/css/prose.css
+++ b/src/css/prose.css
@@ -1,5 +1,5 @@
 .prose {
-  @apply text-zinc-600 leading-loose overflow-hidden;
+  @apply text-zinc-600 leading-loose;
   word-break: break-word;
 }
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->

Fixed post anchor link icon by removing `overflow-hidden` from `.prose` class in `src/css/prose.css`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ab241be</samp>

> _`overflow-hidden`_
> _cutting off the prose like frost_
> _now the text can wrap_

### WHY
<!-- author to complete -->
I don't know why this style was added but it caused the anchor icon not to show up.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ab241be</samp>

* Remove the `overflow-hidden` property from the `.prose` class to prevent text from being cut off in the xLog editor ([link](https://github.com/Crossbell-Box/xLog/pull/363/files?diff=unified&w=0#diff-ee2b13850d8f82fbae8bc911e0261cca67f922e871d05a76f20e78381e26e7bbL2-R2))
