### PR TITLE
feat: page url hash support

### DIFF
--- a/src/pages/_site/[site]/[page].tsx
+++ b/src/pages/_site/[site]/[page].tsx
@@ -52,7 +52,7 @@ function SitePagePage({
   useEffect(() => {
     const [, hash] = asPath.split("#")
     if (hash) {
-      scroller.scrollTo(decodeURI(hash), {
+      scroller.scrollTo(decodeURIComponent(hash), {
         smooth: true,
         offset: -20,
       })

--- a/src/pages/_site/[site]/[page].tsx
+++ b/src/pages/_site/[site]/[page].tsx
@@ -1,12 +1,14 @@
+import { QueryClient } from "@tanstack/react-query"
 import { GetServerSideProps } from "next"
+import { useRouter } from "next/router"
+import { ReactElement, useEffect } from "react"
+import { scroller } from "react-scroll"
 import { SiteLayout } from "~/components/site/SiteLayout"
 import { getServerSideProps as getLayoutServerSideProps } from "~/components/site/SiteLayout.server"
 import { SitePage } from "~/components/site/SitePage"
 import { serverSidePropsHandler } from "~/lib/server-side-props"
-import { QueryClient } from "@tanstack/react-query"
 import { useGetPage } from "~/queries/page"
 import { useGetSite } from "~/queries/site"
-import type { ReactElement } from "react"
 
 export const getServerSideProps: GetServerSideProps = serverSidePropsHandler(
   async (ctx) => {
@@ -45,6 +47,17 @@ function SitePagePage({
     useStat: true,
   })
   const site = useGetSite(domainOrSubdomain)
+
+  const { asPath } = useRouter()
+  useEffect(() => {
+    const [, hash] = asPath.split("#")
+    if (hash) {
+      scroller.scrollTo(decodeURI(hash), {
+        smooth: true,
+        offset: -20,
+      })
+    }
+  }, [])
 
   return <SitePage page={page.data} site={site.data} />
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8175d66</samp>

Added URL hash-based scrolling to site pages. Used `react-scroll` and other hooks to scroll to the corresponding section of a page when the URL hash changes.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 8175d66</samp>

> _Oh we're the coders of the `SitePagePage`_
> _We make the pages scroll with grace_
> _We use the router and the scroller_
> _And the `react-scroll` to set the pace_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8175d66</samp>

*  Implement scrolling to page sections based on URL hash ([link](https://github.com/Crossbell-Box/xLog/pull/364/files?diff=unified&w=0#diff-d08acd20021c4d3a9301a5606cd56e5134ea2672ec670bf5f436074e3ede8a31L1-R11), [link](https://github.com/Crossbell-Box/xLog/pull/364/files?diff=unified&w=0#diff-d08acd20021c4d3a9301a5606cd56e5134ea2672ec670bf5f436074e3ede8a31R51-R61))
  - Add imports for `useRouter`, `useEffect`, `scroller` and `react-scroll` in `src/pages/_site/[site]/[page].tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/364/files?diff=unified&w=0#diff-d08acd20021c4d3a9301a5606cd56e5134ea2672ec670bf5f436074e3ede8a31L1-R11))
  - Add `useEffect` hook to `SitePagePage` component that uses `useRouter` to get `asPath` and `scroller` to scroll to element with matching `id` ([link](https://github.com/Crossbell-Box/xLog/pull/364/files?diff=unified&w=0#diff-d08acd20021c4d3a9301a5606cd56e5134ea2672ec670bf5f436074e3ede8a31R51-R61))
