### PR TITLE
refactor: mobile layout state

### DIFF
--- a/src/hooks/useMobileLayout.ts
+++ b/src/hooks/useMobileLayout.ts
@@ -1,24 +1,31 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect } from "react"
+import { create } from "zustand"
 
 const mobileWidth = 1024
 
+const useLayoutStore = create<{
+  isMobile: boolean | undefined
+}>(() => ({
+  isMobile: undefined,
+}))
+
 export function useMobileLayout() {
-  const [isMobile, setIsMobile] = useState<boolean>()
-
-  const onResize = useCallback(() => {
-    setIsMobile(window.innerWidth < mobileWidth)
+  const calc = useCallback(() => {
+    useLayoutStore.setState({
+      isMobile: window.innerWidth < mobileWidth,
+    })
   }, [])
 
   useEffect(() => {
-    window.addEventListener("resize", onResize)
+    window.addEventListener("resize", calc)
     return () => {
-      window.removeEventListener("resize", onResize)
+      window.removeEventListener("resize", calc)
     }
-  }, [onResize])
+  }, [calc])
 
   useEffect(() => {
-    setIsMobile(window.innerWidth < mobileWidth)
+    calc()
   }, [])
 
-  return isMobile
+  return useLayoutStore((state) => state.isMobile)
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d9aea0f</samp>

Refactored useMobileLayout hook to use zustand for state management. This improves performance and code readability by avoiding unnecessary re-renders and prop drilling.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d9aea0f</samp>

> _`zustand` replaces_
> _`useState` for mobile layout_
> _window resizes_

### WHY
extract mobile state to global

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d9aea0f</samp>

*  Refactor code to use zustand for state management ([link](https://github.com/Crossbell-Box/xLog/pull/365/files?diff=unified&w=0#diff-8e48e3d8e60d4c6a1dee6350a4ab7d0fd0c31ba5967e242f632ebb6ef2bc1387L1-R30))
