### PR TITLE
feat: disable submit button when the comment input box is empty

### DIFF
--- a/src/components/common/CommentInput.tsx
+++ b/src/components/common/CommentInput.tsx
@@ -127,6 +127,12 @@ export const CommentInput: React.FC<{
               commentPage.isLoading ||
               updateComment.isLoading
             }
+            isDisabled={
+              !!account &&
+              userSites.isSuccess &&
+              !!userSites.data?.length &&
+              form.watch("content").trim().length === 0
+            }
           >
             {t(
               account


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99ed5f4</samp>

Disable comment input button for empty comments. This change modifies the `CommentInput` component to check the user and site status before enabling the button.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 99ed5f4</samp>

> _`comment` button off_
> _when user has no content_
> _autumn of silence_

### WHY
<!-- author to complete -->
before:
<img width="914" alt="image" src="https://user-images.githubusercontent.com/89030875/232556248-7f9387e6-f125-49d0-abfb-1f54a99acf21.png">
after:
<img width="945" alt="image" src="https://user-images.githubusercontent.com/89030875/232556504-e97c2984-4163-44cf-8db0-018c98d0cd99.png">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 99ed5f4</samp>

* Disable comment input button for empty comments ([link](https://github.com/Crossbell-Box/xLog/pull/369/files?diff=unified&w=0#diff-5f440bc8d136841d1f8d268a120264525fc1ae488a52dd94010bd2d625d19993R130-R135))
