### PR TITLE
chore: add npmrc to pin registry

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+registry=https://registry.npmjs.org
+
+# https://zenn.dev/haxibami/scraps/083718c1beec04
+strict-peer-dependencies=false


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3dd059d</samp>

Added `.npmrc` file to configure npm registry and peer dependencies. This prevents installation errors for some packages like `react` and `react-dom`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3dd059d</samp>

> _`npmrc` added_
> _To avoid peer errors_
> _Fall leaves are falling_

### WHY
add npmrc to pin registry

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3dd059d</samp>

* Configure npm registry and disable strict peer dependencies check ([link](https://github.com/Crossbell-Box/xLog/pull/377/files?diff=unified&w=0#diff-e813096d69c49812e40e00be9ac8fa14d77f0ec1f97ab4c45cb096b3bedd35deR1-R4))
