### PR TITLE
fix: xss

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "use-onclickoutside": "0.4.1",
     "uuid": "9.0.0",
     "wagmi": "0.12.10",
+    "xss": "1.0.14",
     "zustand": "^4.3.7"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ dependencies:
   wagmi:
     specifier: 0.12.10
     version: 0.12.10(@babel/core@7.21.4)(@types/node@18.15.11)(ethers@5.7.2)(immer@9.0.21)(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.4)
+  xss:
+    specifier: 1.0.14
+    version: 1.0.14
   zustand:
     specifier: ^4.3.7
     version: 4.3.7(immer@9.0.21)(react@18.2.0)
@@ -7051,6 +7054,10 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  /cssfilter@0.0.10:
+    resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
+    dev: false
 
   /csstype@3.0.9:
     resolution: {integrity: sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==}
@@ -14804,6 +14811,15 @@ packages:
   /xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
+    dev: false
+
+  /xss@1.0.14:
+    resolution: {integrity: sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==}
+    engines: {node: '>= 0.10.0'}
+    hasBin: true
+    dependencies:
+      commander: 2.20.3
+      cssfilter: 0.0.10
     dev: false
 
   /xtend@4.0.2:

--- a/src/components/common/CharacterCard.tsx
+++ b/src/components/common/CharacterCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "next-i18next"
 import { useEffect, useState } from "react"
+import xss from "xss"
 
 import { FollowingButton } from "~/components/common/FollowingButton"
 import { FollowingCount } from "~/components/common/FollowingCount"
@@ -83,7 +84,7 @@ export const CharacterCard: React.FC<{
           {site?.description && (
             <span
               className="block text-gray-600"
-              dangerouslySetInnerHTML={{ __html: site?.description || "" }}
+              dangerouslySetInnerHTML={{ __html: xss(site?.description || "") }}
             ></span>
           )}
           {!simple && (

--- a/src/components/common/PatronModal.tsx
+++ b/src/components/common/PatronModal.tsx
@@ -2,6 +2,7 @@ import confetti from "canvas-confetti"
 import { useTranslation } from "next-i18next"
 import { useEffect, useRef, useState } from "react"
 import { toast } from "react-hot-toast"
+import xss from "xss"
 
 import { useAccountState, useConnectModal } from "@crossbell/connect-kit"
 
@@ -146,7 +147,7 @@ export const PatronModal: React.FC<{
           {site?.description && (
             <span
               className="block text-gray-600 text-sm"
-              dangerouslySetInnerHTML={{ __html: site?.description || "" }}
+              dangerouslySetInnerHTML={{ __html: xss(site?.description || "") }}
             ></span>
           )}
         </div>

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -3,6 +3,7 @@ import { FastAverageColor } from "fast-average-color"
 import { useTranslation } from "next-i18next"
 import { useRouter } from "next/router"
 import { MutableRefObject, RefObject, useEffect, useRef, useState } from "react"
+import xss from "xss"
 
 import { XCharLogo, XFeedLogo } from "@crossbell/ui"
 import { RssIcon } from "@heroicons/react/24/solid"
@@ -321,7 +322,9 @@ export const SiteHeader: React.FC<{
               {site?.bio && (
                 <div
                   className="xlog-site-description text-gray-500 leading-snug my-2 sm:my-3 text-sm sm:text-base"
-                  dangerouslySetInnerHTML={{ __html: site?.description || "" }}
+                  dangerouslySetInnerHTML={{
+                    __html: xss(site?.description || ""),
+                  }}
                 ></div>
               )}
               <div className="flex space-x-0 sm:space-x-5 space-y-2 sm:space-y-0 flex-col sm:flex-row text-sm sm:text-base">

--- a/src/components/ui/Mermaid.tsx
+++ b/src/components/ui/Mermaid.tsx
@@ -1,5 +1,6 @@
 import { nanoid } from "nanoid"
 import { FC, useEffect, useState } from "react"
+import xss from "xss"
 
 import { useIsDark } from "~/hooks/useDarkMode"
 import { useIsUnmounted } from "~/hooks/useLifecycle"
@@ -57,7 +58,7 @@ export const Mermaid: FC<{
       Mermaid Loading...
     </div>
   ) : svg ? (
-    <div dangerouslySetInnerHTML={{ __html: svg }} />
+    <div dangerouslySetInnerHTML={{ __html: xss(svg) }} />
   ) : (
     <div className="h-[50px] rounded-lg flex items-center justify-center bg-red-100 text-sm">
       {error || "Error"}

--- a/src/pages/dashboard/[subdomain]/settings/general.tsx
+++ b/src/pages/dashboard/[subdomain]/settings/general.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from "react"
 import type { ReactElement } from "react"
 import { Controller, useForm } from "react-hook-form"
 import toast from "react-hot-toast"
+import xss from "xss"
 
 import { DashboardLayout } from "~/components/dashboard/DashboardLayout"
 import { getServerSideProps as getLayoutServerSideProps } from "~/components/dashboard/DashboardLayout.server"
@@ -63,7 +64,7 @@ export default function SiteSettingsGeneralPage() {
       banner: values.banner,
       site: subdomain,
       name: values.name,
-      description: values.description,
+      description: xss(values.description),
       ga: values.ga,
     })
   })


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 173b03f</samp>

Added `xss` package as a dependency to prevent XSS attacks in various components. Used `xss` to sanitize and escape HTML strings from site descriptions, Mermaid diagrams, and SVG output before rendering them. Updated `pnpm-lock.yaml` and `package.json` with the new dependency.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 173b03f</samp>

> _Sing, O Muse, of the cunning coder who devised_
> _A shield of `xss` against the wicked plots of foes_
> _Who craft malicious scripts to breach the site he prized_
> _And harm the loyal patrons of his epic prose._

### WHY
Fix 0day, XSS attack

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 173b03f</samp>

*  Add `xss` package as a dependency to prevent XSS attacks ([link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R140), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR328-R330), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR14816-R14824))
*  Sanitize and escape HTML strings from site descriptions before setting them as inner HTML in `CharacterCard`, `PatronModal`, and `SiteHeader` components ([link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cR3), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cL86-R87), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-dc83b8c8b24c6289cc57e21506301c2b1b0c5412c91ac8810620a8516bd8a2c9R5), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-dc83b8c8b24c6289cc57e21506301c2b1b0c5412c91ac8810620a8516bd8a2c9L149-R150), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dR6), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL324-R327))
*  Sanitize and escape SVG string from Mermaid library before setting it as inner HTML in `Mermaid` component ([link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-41171ef172b5b1197709973536f58ca087291a8c881fe5333cf1c93980fd2541R3), [link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-41171ef172b5b1197709973536f58ca087291a8c881fe5333cf1c93980fd2541L60-R61))
*  Add `cssfilter` package as a subdependency of `xss` to filter and validate CSS properties and values ([link](https://github.com/Crossbell-Box/xLog/pull/384/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7058-R7061))
