### PR TITLE
feat: Add tag classes when rendering articles

### DIFF
--- a/src/components/site/SitePage.tsx
+++ b/src/components/site/SitePage.tsx
@@ -4,6 +4,7 @@ import serialize from "serialize-javascript"
 
 import { getSiteLink } from "~/lib/helpers"
 import { Note, Profile } from "~/lib/types"
+import { cn } from "~/lib/utils"
 
 import { PageContent } from "../common/PageContent"
 import { PostFooter } from "./PostFooter"
@@ -55,7 +56,7 @@ export const SitePage: React.FC<{
           )}
         </div>
       )}
-      <article>
+      <article className={cn(page?.tags?.map((tag) => `xlog-post-${tag}`))}>
         <div>
           {page?.tags?.includes("post") ? (
             <h2 className="xlog-post-title text-4xl font-bold">{page.title}</h2>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0191a6</samp>

Added dynamic styling for blog posts based on tags using `cn` function in `SitePage.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f0191a6</samp>

> _Oh we're the coders of the sea, we write the code that makes the web go round_
> _We use the `cn` function to style the articles with tags so fine_
> _We heave and ho and push and pull, we make the changes on the count of three_
> _We're the coders of the sea, we write the code that makes the web go round_

### WHY
Now there is no way to control the typesetting format under different tags by customizing css, so when rendering the article, add a class with the tag as the suffix.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0191a6</samp>

* Import and use `cn` function to dynamically assign class names to `article` element based on page tags ([link](https://github.com/Crossbell-Box/xLog/pull/394/files?diff=unified&w=0#diff-4a2104a3828eedd05c4834d2b32b1c01499411eb641fa01ba711abb2331908b6R7), [link](https://github.com/Crossbell-Box/xLog/pull/394/files?diff=unified&w=0#diff-4a2104a3828eedd05c4834d2b32b1c01499411eb641fa01ba711abb2331908b6L58-R59))
