### PR TITLE
feat: Add tag classes when rendering page

### DIFF
--- a/src/components/site/SiteLayout.tsx
+++ b/src/components/site/SiteLayout.tsx
@@ -103,7 +103,10 @@ export const SiteLayout: React.FC<SiteLayoutProps> = ({
       )}
       {site.data && <SiteHeader site={site.data} />}
       <div
-        className={`xlog-post-id-${page.data?.id} max-w-screen-md mx-auto px-5 pt-12 relative`}
+        className={cn(
+          `xlog-post-id-${page.data?.id} max-w-screen-md mx-auto px-5 pt-12 relative`,
+          page.data?.tags?.map((tag) => `xlog-post-tag-${tag}`),
+        )}
       >
         {children}
       </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44a5156</samp>

Added tag-based theming support for xLog pages. Modified `SiteLayout.tsx` to apply different CSS classes to the page content based on the page tags.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 44a5156</samp>

> _`className` changes_
> _divs adapt to page tags_
> _autumn leaves of CSS_

### WHY
Now there is no way to control the typesetting format under different tags by customizing css, so when rendering the article, add a class with the tag as the suffix.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 44a5156</samp>

*  Add tag-based theming for xLog pages by modifying the `className` attribute of the page content wrapper ([link](https://github.com/Crossbell-Box/xLog/pull/395/files?diff=unified&w=0#diff-43426959eff98a692b60240b811291a96f1325bd39fc047cf10e89b32ce18513L106-R109))
