### PR TITLE
fix: fallback the audio cover

### DIFF
--- a/src/markdown/rehype-audio.ts
+++ b/src/markdown/rehype-audio.ts
@@ -25,6 +25,15 @@ export const rehypeAudio: Plugin<Array<{ env: MarkdownEnv }>, Root> = ({
       node.properties.src = toGateway(src)
 
       if (first) {
+        if (
+          !env.cover &&
+          node.properties.cover &&
+          typeof node.properties.cover === "string"
+        ) {
+          const coverIpfsUrl = toGateway(node.properties.cover)
+          node.properties.cover = coverIpfsUrl
+          env.cover = coverIpfsUrl
+        }
         env.audio = node.properties.src
         first = false
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f192ff3</samp>

Add support for cover images for audio files in `src/markdown/rehype-audio.ts`. Use `toGateway` to convert IPFS hashes to URLs and store them in `env` and `node` objects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f192ff3</samp>

> _`cover` from IPFS_
> _adds a gateway URL to `env`_
> _autumn leaves falling_

### WHY
When there is no picture cover, the cover falls back to the first audio cover.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f192ff3</samp>

*  Add cover image support for audio files ([link](https://github.com/Crossbell-Box/xLog/pull/401/files?diff=unified&w=0#diff-b3ddc360a26938438ccf477a01de8c384331627dd2ec886ca842c1fdd4f78825R28-R36))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
