### PR TITLE
feat: toast error when renderPageContent error

### DIFF
--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -2,6 +2,7 @@ import type { Root } from "hast"
 import jsYaml from "js-yaml"
 import { Result as TocResult, toc } from "mdast-util-toc"
 import { ReactElement, createElement } from "react"
+import { toast } from "react-hot-toast"
 import { Element } from "react-scroll"
 import { refractor } from "refractor"
 import rehypeAutolinkHeadings from "rehype-autolink-headings"
@@ -207,8 +208,10 @@ export const renderPageContent = (
       .processSync(content)
 
     contentHTML = result.toString()
-  } catch (error) {
-    console.error(error)
+  } catch (e) {
+    const error = e as Error
+    toast.error(error.message)
+    console.error(e)
   }
   return {
     contentHTML,

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -210,7 +210,7 @@ export const renderPageContent = (
     contentHTML = result.toString()
   } catch (e) {
     const error = e as Error
-    toast.error(error.message)
+    toast.error(error?.message)
     console.error(e)
   }
   return {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee828fa</samp>

Improved markdown rendering by adding error handling and notifications in `src/markdown/index.ts`. Used `toast` function to show user-friendly messages when parsing fails.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ee828fa</samp>

> _Oh we're the crew of the `renderPageContent`_
> _We parse the markdown with skill and intent_
> _But if we encounter an error or a glitch_
> _We'll notify the user with a `toast` and a switch_

### WHY
editor preview not work without telling user error message

before:
<img width="1484" alt="before" src="https://user-images.githubusercontent.com/4584859/233775667-522adf76-e8f3-498f-92f4-f39218f0c4ff.png">

after:
![after](https://user-images.githubusercontent.com/4584859/233775873-838167de-af36-401e-947a-5c5cf1740179.png)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ee828fa</samp>

* Import `toast` function from `react-hot-toast` library to display notifications ([link](https://github.com/Crossbell-Box/xLog/pull/405/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR5))
* Handle errors when parsing markdown files in `renderPageContent` function ([link](https://github.com/Crossbell-Box/xLog/pull/405/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcL210-R214))
* Update `src/markdown/index.ts` file with error handling logic and `toast` import ([link](https://github.com/Crossbell-Box/xLog/pull/405/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR5),[link](https://github.com/Crossbell-Box/xLog/pull/405/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcL210-R214))

### CLAIM REWARDS
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
xLog address: 0xdC18f7DB2af9b8c37F57022FdA12bF865E685901
Discord ID: 445503136841465860
