### PR TITLE
fix: allow reference of float card to expand based on content

### DIFF
--- a/src/components/common/CharacterFloatCard.tsx
+++ b/src/components/common/CharacterFloatCard.tsx
@@ -43,7 +43,11 @@ export const CharacterFloatCard: React.FC<{
 
   return (
     <>
-      <span className="inline" ref={refs.setReference} {...getReferenceProps()}>
+      <span
+        className="inline-block"
+        ref={refs.setReference}
+        {...getReferenceProps()}
+      >
         {children}
       </span>
       {isMounted && (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcd92f7</samp>

Fixed a UI bug in the character float card component and improved the layout of the xLog app. Changed the `className` prop of a `span` element in `CharacterFloatCard.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bcd92f7</samp>

> _`inline-block` span_
> _fixes float card overlap_
> _a winter UI_

### WHY
<!-- author to complete -->
The card doesn't position properly if user avatar is not set.

<img width="575" alt="image" src="https://user-images.githubusercontent.com/1141198/233781119-33ee1be3-9e97-4559-b691-ae2e97681192.png">
<img width="575" alt="image" src="https://user-images.githubusercontent.com/1141198/233781129-90875c02-d42b-4ad1-9361-61e37c1dfec3.png">


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bcd92f7</samp>

* Fix layout issue of character float card by changing `className` prop of `span` element from `inline` to `inline-block` ([link](https://github.com/Crossbell-Box/xLog/pull/406/files?diff=unified&w=0#diff-31807aabca64537dbb8e500ba04fc6e78e3e9463d30ded7b25347c4bb98ca896L46-R50))

### CLAIM REWARDS
<!-- author to complete -->

My address: 0x0384D68A518C18C00438e1bBd990b8EebfDbD0bF
