### PR TITLE
fix: search icon position, closes #406

### DIFF
--- a/src/components/common/SearchInput.tsx
+++ b/src/components/common/SearchInput.tsx
@@ -26,7 +26,7 @@ export const SearchInput: React.FC<{
     <div className="xlog-comment-input flex">
       <form className="w-full relative" onSubmit={handleSubmit}>
         <div
-          className="absolute left-0 top-1/2 -translate-y-1/2 text-2xl text-zinc-500 h-11 w-14 flex items-center justify-center cursor-pointer"
+          className="absolute left-0 top-1/2 -translate-y-1/2 text-2xl text-zinc-500 h-11 ml-4 flex items-center justify-center cursor-pointer"
           onClick={handleSubmit}
         >
           <i className="i-mingcute:search-line block" />


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba1b4df</samp>

Adjusted the position of the search icon in `SearchInput.tsx` to improve the UI layout.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ba1b4df</samp>

> _`search icon` shifts_
> _a margin of four pixels_
> _autumn leaves adjust_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ba1b4df</samp>

*  Adjust the margin-left of the search icon to 4px to improve alignment and spacing ([link](https://github.com/Crossbell-Box/xLog/pull/414/files?diff=unified&w=0#diff-31f40f221564272f24ebdb99726eeef1d0aeb3c911d8b7bbd216bf1a52f7cb07L29-R29))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
