### PR TITLE
fix table of content active highlight

### DIFF
--- a/src/components/site/PostToc.tsx
+++ b/src/components/site/PostToc.tsx
@@ -19,6 +19,10 @@ function getIds(items: TocResult["map"]) {
   )
 }
 
+function getElement(id: string) {
+  return document.querySelector(`a[href="#${id}"]`)
+}
+
 function useActiveId(itemIds: string[]) {
   const [activeId, setActiveId] = useState(`test`)
   useEffect(() => {
@@ -26,21 +30,21 @@ function useActiveId(itemIds: string[]) {
       (entries) => {
         entries.forEach((entry) => {
           if (entry.isIntersecting) {
-            setActiveId(entry.target.id)
+            setActiveId(entry.target.getAttribute("href") || "test")
           }
         })
       },
       { rootMargin: `0% 0% -80% 0%` },
     )
     itemIds.forEach((id) => {
-      const element = document.getElementById(id)
+      const element = getElement(id)
       if (element) {
         observer.observe(element)
       }
     })
     return () => {
       itemIds.forEach((id) => {
-        const element = document.getElementById(id)
+        const element = getElement(id)
         if (element) {
           observer.unobserve(element)
         }
@@ -81,7 +85,7 @@ function renderItems(items: TocResult["map"], activeId: string, prefix = "") {
                     href={child.children[0].url}
                     title={content}
                     className={
-                      (activeId === child.children[0].url.slice(1)
+                      (activeId === child.children[0].url
                         ? "text-accent"
                         : "text-zinc-700") +
                       " truncate inline-block max-w-full align-bottom hover:text-accent"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6a712f3</samp>

Improve `PostToc` component logic and performance. Use `href` instead of `id` to track active sections in the table of contents.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 6a712f3</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The PostToc component, a guide for the reader's mind_
> _He devised a new function, `getElement`, to find_
> _The anchor's `href`, not the `id` of the section behind_

### WHY
active id currently not working in table of content,because of the 'user-content' prefix add to header id

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6a712f3</samp>

*  Add `getElement` function to return an anchor element by id ([link](https://github.com/Crossbell-Box/xLog/pull/421/files?diff=unified&w=0#diff-102618deb90e88f122ec45f54cdb0097526040dc30fc1a726767942581e7709bR22-R25))
*  Use `href` attribute of anchor element instead of `id` attribute of target element in `useActiveId` hook to match the table of contents ([link](https://github.com/Crossbell-Box/xLog/pull/421/files?diff=unified&w=0#diff-102618deb90e88f122ec45f54cdb0097526040dc30fc1a726767942581e7709bL29-R33), [link](https://github.com/Crossbell-Box/xLog/pull/421/files?diff=unified&w=0#diff-102618deb90e88f122ec45f54cdb0097526040dc30fc1a726767942581e7709bL36-R40), [link](https://github.com/Crossbell-Box/xLog/pull/421/files?diff=unified&w=0#diff-102618deb90e88f122ec45f54cdb0097526040dc30fc1a726767942581e7709bL43-R47))
*  Simplify `renderItems` function by using `url` property of child node instead of slicing the first character ([link](https://github.com/Crossbell-Box/xLog/pull/421/files?diff=unified&w=0#diff-102618deb90e88f122ec45f54cdb0097526040dc30fc1a726767942581e7709bL84-R88))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
