### PR TITLE
chore: fix pm2 config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,5 +45,6 @@ COPY --from=build /app/.next/standalone /app
 COPY --from=build /app/public /app/public
 COPY --from=build /app/.next/static /app/.next/static
 COPY --from=build /app/prisma /app/prisma
+COPY --from=build /app/ecosystem.config.js /app/ecosystem.config.js
 
-CMD ["pm2-runtime", "start", "pnpm", "--", "start", "-i", "2"]
+CMD ["pm2-runtime", "start", "-i", "2", "ecosystem.config.js"]

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  apps: [
+    {
+      instances: 2,
+      name: "xlog",
+      script: "./server.js",
+    },
+  ],
+}


### PR DESCRIPTION
### WHAT
fix pm2 config

### WHY
If pm2 starts `pnpm start`, it will report an error: address already in use