### PR TITLE
feat: add support for return back home

### DIFF
--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from "next/router"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 
 import {
   useAccountState,
@@ -19,14 +19,38 @@ export default function Dashboard() {
   ])
   const connectModal = useConnectModal()
 
+  const isConnectModalShown = useRef(false)
+  const isMintCharacterModalShown = useRef(false)
+
   useEffect(() => {
     if (ssrReady) {
+      // Wait till SSR is ready
       if (!isConnected) {
-        connectModal.show()
+        // Wallet not connected
+        if (!isConnectModalShown.current) {
+          // Not shown
+          isConnectModalShown.current = true
+          connectModal.show()
+        } else if (!connectModal.isActive) {
+          // Shown, but closed by user
+          router.push("/") // Go back home
+        }
       } else if (userSites.isSuccess) {
+        // Wallet is connected, wait till site is ready
+        // Reset connect wallet status to prevent unexpected redirect
+        isConnectModalShown.current = false
         if (!userSites.data?.length) {
-          walletMintNewCharacterModal.show()
+          // No character found, prompt to mint one
+          if (!isMintCharacterModalShown.current) {
+            // Not shown
+            isMintCharacterModalShown.current = true
+            walletMintNewCharacterModal.show()
+          } else if (!walletMintNewCharacterModal.isActive) {
+            // Shown, but closed by user
+            router.push("/") // Go back home
+          }
         } else {
+          // Already have characters, redirect to primary
           router.push(`/dashboard/${userSites.data[0].username}`)
         }
       }


### PR DESCRIPTION
...if user don't want to mint character now. Or maybe we can redirect to character introduction page?

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53b3025</samp>

Improved dashboard page UX and modal handling with `useRef` hook. Refactored `src/pages/dashboard/index.tsx` to avoid unwanted redirects.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 53b3025</samp>

> _Oh we're the coders of the dashboard page_
> _And we've refactored it with skill and rage_
> _We've used `useRef` for the modal state_
> _And handled cancellation without a wait_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 53b3025</samp>

* Refactored the logic for showing the connect wallet and mint character modals on the dashboard page ([link](https://github.com/Crossbell-Box/xLog/pull/435/files?diff=unified&w=0#diff-f2a65ccf5cb50c2109c54e92fd42ab51d343877dcecba4e17b28b50dd502faabL2-R2), [link](https://github.com/Crossbell-Box/xLog/pull/435/files?diff=unified&w=0#diff-f2a65ccf5cb50c2109c54e92fd42ab51d343877dcecba4e17b28b50dd502faabL22-R53))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
