### PR TITLE
fix: remove double slash

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -38,7 +38,7 @@ export const getSlugUrl = (slug: string) => {
     }
   }
 
-  return `/${slug}`
+  return slug
 }
 
 export const getNoteSlug = (note: NoteEntity) => {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 129263b</samp>

Fixed a bug with Next.js links by removing the leading slash from the slug URL. Modified the `getSlugUrl` function in `src/lib/helpers.ts` to implement this change.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 129263b</samp>

> _`getSlugUrl` changed_
> _No slash for `Link` component_
> _Winter bug is fixed_

### WHY

To fix `Invalid href '//note-144' passed to next/router in page: '/_site/[site]'. Repeated forward-slashes (//) or backslashes \ are not valid in the href.`

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 129263b</samp>

* Fix link bug by removing leading slash from slug URL ([link](https://github.com/Crossbell-Box/xLog/pull/443/files?diff=unified&w=0#diff-26999e6f9a7fac03a622245890c5bb7f2d49a102fc8b4aaed94001b7be8d7fb3L41-R41))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
