### PR TITLE
fix: reduce empty array

### DIFF
--- a/src/pages/dashboard/[subdomain]/index.tsx
+++ b/src/pages/dashboard/[subdomain]/index.tsx
@@ -68,7 +68,7 @@ export default function SubdomainIndex() {
       value: `${
         tips.data?.pages?.[0]?.list
           ?.map((i) => +i.amount)
-          .reduce((acr, cur) => acr + cur) || 0
+          .reduce((acr, cur) => acr + cur, 0) ?? 0
       } MIRA`,
       url: `/dashboard/${subdomain}/tokens`,
     },


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d5af8a</samp>

Fixed a bug in the dashboard page that caused the total tips to show NaN when empty. Used `reduce` with an initial value and `??` operator to handle empty and falsy values.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1d5af8a</samp>

> _`reduce` gets zero_
> _No more NaN for empty_
> _Tips in autumn wind_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1d5af8a</samp>

* Fix a bug where the total amount of tips was displayed as NaN when there were no tips by providing an initial value of 0 to the `reduce` method and using the nullish coalescing operator `??` instead of the logical OR operator `||` ([link](https://github.com/Crossbell-Box/xLog/pull/447/files?diff=unified&w=0#diff-cfb4b228f6eaf695a4afaaddfcd1182dc931d42a85d20e6d40f2bf3483376c91L71-R71))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
