### PR TITLE
perf(a11y): add focus-visible outline to BlockchainInfo

### DIFF
--- a/src/components/common/BlockchainInfo.tsx
+++ b/src/components/common/BlockchainInfo.tsx
@@ -28,7 +28,7 @@ export const BlockchainInfo: React.FC<{
         {({ open }: { open: boolean }) => (
           <>
             <Disclosure.Button
-              className="flex w-full justify-between items-center rounded-lg px-4 py-2 text-left text-gray-900 hover:bg-hover transition-colors md:rounded-xl"
+              className="flex w-full justify-between items-center rounded-lg px-4 py-2 text-left text-gray-900 hover:bg-hover transition-colors md:rounded-xl focus-visible:ring focus-visible:ring-accent focus-visible:ring-opacity-50"
               aria-label="toggle chain info"
               data-hide-print
             >
@@ -53,17 +53,14 @@ export const BlockchainInfo: React.FC<{
                 <li>
                   <div className="font-medium">{t("Owner")}</div>
                   <div>
-                    <a
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-block mr-4 break-all"
+                    <BlockchainInfoLink
                       href={`${CSB_SCAN}/address/${
                         page?.metadata?.owner || site?.metadata?.owner
                       }`}
                       key={page?.metadata?.owner || site?.metadata?.owner}
                     >
                       {page?.metadata?.owner || site?.metadata?.owner}
-                    </a>
+                    </BlockchainInfoLink>
                   </div>
                 </li>
                 <li>
@@ -74,35 +71,26 @@ export const BlockchainInfo: React.FC<{
                           ?.filter((url) => url.startsWith(CSB_SCAN + "/tx/"))
                           .map((url, index) => {
                             return (
-                              <a
-                                target="_blank"
-                                rel="noreferrer"
-                                className="inline-block mr-4 break-all"
-                                href={url}
-                                key={url}
-                              >
+                              <BlockchainInfoLink href={url} key={url}>
                                 {t(index === 0 ? "Creation" : "Last Update")}{" "}
                                 {url
                                   .replace(CSB_SCAN + "/tx/", "")
                                   .slice(0, 10)}
                                 ...
                                 {url.replace(CSB_SCAN + "/tx/", "").slice(-10)}
-                              </a>
+                              </BlockchainInfoLink>
                             )
                           })
                       : site?.metadata?.transactions.map(
                           (hash: string, index: number) => {
                             return (
-                              <a
-                                target="_blank"
-                                rel="noreferrer"
-                                className="inline-block mr-4 break-all"
+                              <BlockchainInfoLink
                                 href={`${CSB_SCAN}/tx/${hash}`}
                                 key={hash}
                               >
                                 {t(index === 0 ? "Creation" : "Last Update")}{" "}
                                 {hash.slice(0, 10)}...{hash.slice(-10)}
-                              </a>
+                              </BlockchainInfoLink>
                             )
                           },
                         )}
@@ -111,14 +99,9 @@ export const BlockchainInfo: React.FC<{
                 <li>
                   <div className="font-medium">{t("IPFS Address")}</div>
                   <div>
-                    <a
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-block mr-4 break-all"
-                      href={toGateway(ipfs)}
-                    >
+                    <BlockchainInfoLink href={toGateway(ipfs)}>
                       {toIPFS(ipfs)}
-                    </a>
+                    </BlockchainInfoLink>
                   </div>
                 </li>
                 {greenfieldId.data?.greenfieldId && (
@@ -127,10 +110,7 @@ export const BlockchainInfo: React.FC<{
                       {t("BNB Greenfield Address")}
                     </div>
                     <div>
-                      <a
-                        target="_blank"
-                        rel="noreferrer"
-                        className="inline-block mr-4 break-all"
+                      <BlockchainInfoLink
                         href={
                           "https://greenfieldscan.com/" +
                           (greenfieldId.data?.transactionHash
@@ -139,7 +119,7 @@ export const BlockchainInfo: React.FC<{
                         }
                       >
                         {greenfieldId.data?.greenfieldId}
-                      </a>
+                      </BlockchainInfoLink>
                     </div>
                   </li>
                 )}
@@ -149,5 +129,22 @@ export const BlockchainInfo: React.FC<{
         )}
       </Disclosure>
     </div>
+  )
+}
+
+function BlockchainInfoLink({
+  className,
+  ...props
+}: React.AnchorHTMLAttributes<HTMLAnchorElement>) {
+  return (
+    <a
+      target="_blank"
+      rel="noreferrer"
+      className={cn(
+        "inline-block mr-4 break-all focus-visible:ring focus-visible:ring-accent",
+        className,
+      )}
+      {...props}
+    />
   )
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a044122</samp>

Refactor `BlockchainInfo` component to use custom link component and add focus ring style. This enhances the UI and code quality of the component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at a044122</samp>

> _To make the code more concise and clear_
> _The `BlockchainInfo` got a new gear_
> _It uses `BlockchainInfoLink`_
> _For external links that blink_
> _And a focus ring for the button to appear_

### WHY
Make the focused element recognizable when user is navigating with keyboard.

https://user-images.githubusercontent.com/8225666/235047225-33f06116-6ce1-4576-8f58-925aec90b68a.mov

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a044122</samp>

*  Added a custom `BlockchainInfoLink` component to simplify external links in `BlockchainInfo.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL56-R56), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL66-R63), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL77-R74), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL90-R81), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL96-R87), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL105-R93), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL114-R104), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL130-R113), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL142-R122), [link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bR134-R150))
*  Added a focus-visible ring style to the `Disclosure.Button` component for accessibility in `BlockchainInfo.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/448/files?diff=unified&w=0#diff-ed03f2bb2817deec3f5f032fc2476a091387045531320f1b5eb699758f3d767bL31-R31))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
xLog ID `doma-6565`
Discord `Doma#0599`