### PR TITLE
perf(a11y): add focus outline to SiteHeader buttons and links

### DIFF
--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -44,12 +44,9 @@ const HeaderLink: React.FC<{ link: HeaderLinkType }> = ({ link }) => {
     <UniLink
       href={link.url}
       onClick={link.onClick}
-      className={cn(
-        `xlog-site-navigation-item h-10 flex items-center space-x-1 transition-colors relative after:content-[''] hover:after:w-full hover:after:left-0 after:transition-[width,left] after:h-[2px] after:block after:absolute after:bottom-0`,
-        active
-          ? `text-accent after:w-full after:left-0 after:bg-accent`
-          : `hover:text-gray-700 after:w-0 after:left-1/2 after:bg-gray-700`,
-      )}
+      className={cn("xlog-site-navigation-item", {
+        "xlog-site-navigation-item-active": active,
+      })}
     >
       {link.icon && <span>{link.icon}</span>}
       <span className="whitespace-nowrap">{t(link.label)}</span>
@@ -335,7 +332,7 @@ export const SiteHeader: React.FC<{
           </div>
         </div>
         <div className="text-gray-500 flex items-center justify-between w-full mt-auto">
-          <div className="xlog-site-navigation flex items-center space-x-5 min-w-0 overflow-x-auto text-sm sm:text-base">
+          <div className="xlog-site-navigation flex items-center gap-1 mx-[-.5rem] min-w-0 text-sm sm:text-base">
             {leftLinks.map((link, i) => {
               return <HeaderLink link={link} key={`${link.label}${i}`} />
             })}

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -91,6 +91,7 @@ a {
   @apply font-medium;
   @apply transition;
   @apply active:scale-95;
+  @apply focus-visible:ring focus-visible:ring-accent focus-visible:ring-opacity-50 focus-within:ring-offset-1;
 }
 
 .button.is-auto-width {

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -15,6 +15,12 @@
   }
 }
 
+@layer utilities {
+  .focus-ring {
+    @apply focus-visible:outline focus-visible:outline-accent;
+  }
+}
+
 *,
 *:after,
 *:before {
@@ -91,7 +97,7 @@ a {
   @apply font-medium;
   @apply transition;
   @apply active:scale-95;
-  @apply focus-visible:ring focus-visible:ring-accent focus-visible:ring-opacity-50 focus-within:ring-offset-1;
+  @apply focus-ring focus-within:ring-offset-1;
 }
 
 .button.is-auto-width {
@@ -398,4 +404,23 @@ textarea.input {
 .xlog-post-toc .katex {
   font: unset;
   line-height: unset;
+}
+
+.xlog-site-navigation-item {
+  @apply h-10 px-2 flex items-center space-x-1 transition-colors focus-ring;
+  @apply hover:text-gray-700;
+
+  /* The underline */
+  @apply relative;
+  @apply after:absolute after:block after:content-[''] after:h-[2px] after:transition-[left,right] after:bottom-0 after:left-1/2 after:right-1/2 after:bg-gray-700;
+  @apply hover:after:left-2 hover:after:right-2;
+}
+
+/* TODO-Doma */
+/* Maybe use CSS nested syntax */
+.xlog-site-navigation-item-active {
+  @apply text-accent hover:text-accent;
+
+  /* The underline */
+  @apply after:left-2 after:right-2 after:bg-accent;
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f91f15</samp>

Enhanced the site header component with better styling and accessibility. Used `padding` and `gap` utilities to adjust the layout, and added a custom `.focus-ring` class to `src/css/tailwind.css` for keyboard navigation.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0f91f15</samp>

> _Sing, O Muse, of the skillful coder who refined_
> _The header of the site, where the logo and links shine_
> _With padding and gap utilities he made them fit and fair_
> _And added a focus ring, like the halo of a star_

### WHY
Make focused element more recognizable when user is navigating with keyboard.

https://user-images.githubusercontent.com/8225666/235047444-9a982e92-33c0-4b11-909e-7a468b1cf243.mov

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0f91f15</samp>

* Add horizontal padding and improve wrapping for navigation items in the header ([link](https://github.com/Crossbell-Box/xLog/pull/449/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL48-R48), [link](https://github.com/Crossbell-Box/xLog/pull/449/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL338-R338), [link](https://github.com/Crossbell-Box/xLog/pull/449/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R100), [link](https://github.com/Crossbell-Box/xLog/pull/449/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R408-R411))
* Define and use `.focus-ring` utility class for custom outline and ring style on focused elements ([link](https://github.com/Crossbell-Box/xLog/pull/449/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R18-R23), [link](https://github.com/Crossbell-Box/xLog/pull/449/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R100), [link](https://github.com/Crossbell-Box/xLog/pull/449/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R408-R411))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
