### PR TITLE
fix: top bar style when window width less than 1024px

### DIFF
--- a/src/components/dashboard/DashboardTopbar.tsx
+++ b/src/components/dashboard/DashboardTopbar.tsx
@@ -64,7 +64,6 @@ export const DashboardTopbar: React.FC<{
       </div>
       <div className="flex-1"></div>
       {userWidget}
-      <div className="w-[1px] bg-border absolute top-0 right-0 bottom-0"></div>
     </div>
   )
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f5bf65</samp>

Removed a border div from `DashboardTopbar.tsx` to fix a visual bug on the dashboard topbar.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2f5bf65</samp>

> _`border` div gone_
> _No more thin line on topbar_
> _Winter's clarity_

### WHY
In the window width less than 1024px , a small edge will appear to the right of the avatar, which is not as expected but is expected in side bar when layout width more than 1024px.
TopBar:
<img width="868" alt="image" src="https://user-images.githubusercontent.com/98948357/235061069-d019d17a-c8be-4e89-ac2a-74bafb480651.png">
SideBar:
<img width="380" alt="image" src="https://user-images.githubusercontent.com/98948357/235061658-bbc21622-96aa-452e-a59e-d582f2e0142b.png">


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2f5bf65</samp>

* Removed redundant border div from topbar component ([link](https://github.com/Crossbell-Box/xLog/pull/453/files?diff=unified&w=0#diff-d218b6d1c24258e372085e225c38aab153a05452cfec47ade671b3d1d4bf1fb6L67))

### CLAIM REWARDS
https://hai-7651.xlog.app/
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
