### PR TITLE
feat: register j/tsx syntax highlight

### DIFF
--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -5,6 +5,8 @@ import { ReactElement, createElement } from "react"
 import { toast } from "react-hot-toast"
 import { Element } from "react-scroll"
 import { refractor } from "refractor"
+import jsx from "refractor/lang/jsx"
+import tsx from "refractor/lang/tsx"
 import rehypeAutolinkHeadings from "rehype-autolink-headings"
 import rehypeInferDescriptionMeta from "rehype-infer-description-meta"
 import rehypeKatex from "rehype-katex"
@@ -69,6 +71,8 @@ export type Rendered = {
 }
 
 refractor.alias("html", ["svelte", "vue"])
+refractor.register(tsx)
+refractor.register(jsx)
 
 const rehypePrism = rehypePrismGenerator(refractor)
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 223dbc4</samp>

Add React and TypeScript syntax highlighting for markdown files. The file `src/markdown/index.ts` imports and registers the `jsx` and `tsx` modules from `refractor`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 223dbc4</samp>

> _We're sailing on the markdown sea_
> _With `React` and `TypeScript` we_
> _Highlight our code with `refractor`_
> _One, two, three, pull and hoist the anchor_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 223dbc4</samp>

* Enable syntax highlighting for React and TypeScript code snippets in markdown files ([link](https://github.com/Crossbell-Box/xLog/pull/455/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR8-R9), [link](https://github.com/Crossbell-Box/xLog/pull/455/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR74-R75))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
