### PR TITLE
fix: filter same tags in editor

### DIFF
--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -207,8 +207,10 @@ export default function SubdomainEditor() {
     if (check) {
       toast.error(check)
     } else {
+      const uniqueTags = Array.from(new Set(values.tags.split(","))).join(",")
       createOrUpdatePage.mutate({
         ...values,
+        tags: uniqueTags,
         slug: values.slug || defaultSlug,
         siteId: subdomain,
         ...(visibility === PageVisibilityEnum.Draft ? {} : { pageId: pageId }),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 164bc35</samp>

Fix duplicate tags issue in page editor. The change ensures that only unique tags are passed to the `createOrUpdatePage` mutation in `src/pages/dashboard/[subdomain]/editor.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 164bc35</samp>

> _`values` has tags_
> _Some may be duplicates_
> _Strip them with code_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 164bc35</samp>

*  Prevent duplicate tags from being stored and displayed by filtering them out from the values object before calling the `createOrUpdatePage` mutation ([link](https://github.com/Crossbell-Box/xLog/pull/457/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L210-R213))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
