### PR TITLE
fix: CJKT users IME composition

### DIFF
--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -580,7 +580,7 @@ export default function SubdomainEditor() {
                       name="title"
                       value={values.title}
                       onKeyDown={(e) => {
-                        if (e.key === "Enter") {
+                        if (e.key === "Enter" && !e.nativeEvent.isComposing) {
                           view?.focus()
                         }
                       }}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6c0d54</samp>

Fixed a bug that caused the editor view to lose focus when typing in non-Latin languages. Modified the `Enter` key handler in `editor.tsx` to respect the input composition state.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b6c0d54</samp>

> _`Enter` key pressed_
> _Editor view shifts focus_
> _Not while composing_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6c0d54</samp>

*  Prevent editor focus from shifting when typing in different input methods ([link](https://github.com/Crossbell-Box/xLog/pull/458/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L583-R583))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
