### PR TITLE
chore: remove aplayer as deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@uiw/codemirror-extensions-events": "4.19.16",
     "@urql/core": "4.0.7",
     "ahooks": "^3.7.6",
-    "aplayer": "^1.10.1",
     "aplayer-react": "^1.1.0",
     "axios": "1.4.0",
     "canvas-confetti": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,9 +97,6 @@ dependencies:
   ahooks:
     specifier: ^3.7.6
     version: 3.7.6(react@18.2.0)
-  aplayer:
-    specifier: ^1.10.1
-    version: 1.10.1
   aplayer-react:
     specifier: ^1.1.0
     version: 1.1.0(react@18.2.0)
@@ -5661,14 +5658,6 @@ packages:
       use-sync-external-store: 1.2.0(react@18.2.0)
     dev: false
 
-  /aplayer@1.10.1:
-    resolution: {integrity: sha512-HAfyxgCUTLAqtYlxzzK9Fyqg6y+kZ9CqT1WfeWE8FSzwspT6oBqWOZHANPHF3RGTtC33IsyEgrfthPDzU5r9kQ==}
-    dependencies:
-      balloon-css: 0.5.2
-      promise-polyfill: 7.1.0
-      smoothscroll: 0.4.0
-    dev: false
-
   /aproba@2.0.0:
     resolution: {integrity: sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==}
     dev: false
@@ -5986,10 +5975,6 @@ packages:
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
-  /balloon-css@0.5.2:
-    resolution: {integrity: sha512-zheJpzwyNrG4t39vusA67v3BYg1HTVXOF8cErPEHzWK88PEOFwgo6Ea9VHOgOWNMgeuOtFVtB73NE2NWl9uDyQ==}
-    dev: false
 
   /base-x@3.0.9:
     resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
@@ -11495,10 +11480,6 @@ packages:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
     dev: false
 
-  /promise-polyfill@7.1.0:
-    resolution: {integrity: sha512-P6NJ2wU/8fac44ENORsuqT8TiolKGB2u0fEClPtXezn7w5cmLIjM/7mhPlTebke2EPr6tmqZbXvnX0TxwykGrg==}
-    dev: false
-
   /prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
     dependencies:
@@ -12591,10 +12572,6 @@ packages:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
     dev: true
-
-  /smoothscroll@0.4.0:
-    resolution: {integrity: sha512-sggQ3U2Un38b3+q/j1P4Y4fCboCtoUIaBYoge+Lb6Xg1H8RTIif/hugVr+ErMtIDpvBbhQfTjtiTeYAfbw1ZGQ==}
-    dev: false
 
   /sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,4 @@
-import "aplayer/dist/APlayer.min.css"
+import "aplayer-react/dist/index.css"
 import { Network } from "crossbell.js"
 import { appWithTranslation } from "next-i18next"
 import NextNProgress from "nextjs-progressbar"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13f8af7</samp>

This pull request updates the audio player component from `aplayer` to `aplayer-react`, which is a React wrapper for the same library. It removes the unused `aplayer` package and its dependencies, and adjusts the import statements in the custom App component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 13f8af7</samp>

> _To play audio on the web page_
> _We used `aplayer` at one stage_
> _But now we prefer_
> _The `aplayer-react` wrapper_
> _So we changed the import and lock file to engage_

### WHY
According to https://github.com/SevenOutman/aplayer-react/pull/14, remove aplayer as dependency.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 13f8af7</samp>

* Replace `aplayer` package with `aplayer-react` package for web audio player functionality ([link](https://github.com/Crossbell-Box/xLog/pull/460/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL100-L102), [link](https://github.com/Crossbell-Box/xLog/pull/460/files?diff=unified&w=0#diff-88a36bc7a53bfa58c6f451464798d631d785160dfacfdaf9479be7a0b1d7e5e5L1-R1))
* Remove unused entries for `aplayer` and its dependencies from `pnpm-lock.yaml` file ([link](https://github.com/Crossbell-Box/xLog/pull/460/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5664-L5671), [link](https://github.com/Crossbell-Box/xLog/pull/460/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5990-L5993), [link](https://github.com/Crossbell-Box/xLog/pull/460/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11498-L11501), [link](https://github.com/Crossbell-Box/xLog/pull/460/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL12595-L12598))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
