### PR TITLE
fix: light/dark mode does not working whe the site page is first mounted

### DIFF
--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -16,7 +16,6 @@ import { Image } from "~/components/ui/Image"
 import { Menu } from "~/components/ui/Menu"
 import { Modal } from "~/components/ui/Modal"
 import { Tooltip } from "~/components/ui/Tooltip"
-import { useDarkMode } from "~/hooks/useDarkMode"
 import { useIsDark } from "~/hooks/useDarkMode"
 import { CSB_IO, CSB_SCAN, CSB_XCHAR } from "~/lib/env"
 import { Profile } from "~/lib/types"
@@ -137,7 +136,6 @@ export const SiteHeader: React.FC<{
   const avatarRef = useRef<HTMLImageElement>(null)
   const bannerRef = useRef<HTMLImageElement | HTMLVideoElement>(null)
 
-  useDarkMode()
   const isDark = useIsDark()
   const [averageColor, setAverageColor] = useState<string>()
   const [autoHoverColor, setAutoHoverColor] = useState<string>()

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -16,6 +16,7 @@ import { Image } from "~/components/ui/Image"
 import { Menu } from "~/components/ui/Menu"
 import { Modal } from "~/components/ui/Modal"
 import { Tooltip } from "~/components/ui/Tooltip"
+import { useDarkMode } from "~/hooks/useDarkMode"
 import { useIsDark } from "~/hooks/useDarkMode"
 import { CSB_IO, CSB_SCAN, CSB_XCHAR } from "~/lib/env"
 import { Profile } from "~/lib/types"
@@ -136,6 +137,7 @@ export const SiteHeader: React.FC<{
   const avatarRef = useRef<HTMLImageElement>(null)
   const bannerRef = useRef<HTMLImageElement | HTMLVideoElement>(null)
 
+  useDarkMode()
   const isDark = useIsDark()
   const [averageColor, setAverageColor] = useState<string>()
   const [autoHoverColor, setAutoHoverColor] = useState<string>()

--- a/src/components/site/SiteLayout.tsx
+++ b/src/components/site/SiteLayout.tsx
@@ -6,6 +6,7 @@ import { useAccountState } from "@crossbell/connect-kit"
 import { BlockchainInfo } from "~/components/common/BlockchainInfo"
 import { Style } from "~/components/common/Style"
 import { useUserRole } from "~/hooks/useUserRole"
+import { useDarkMode } from "~/hooks/useDarkMode"
 import { IS_PROD } from "~/lib/constants"
 import { OUR_DOMAIN, SITE_URL } from "~/lib/env"
 import { getUserContentsUrl } from "~/lib/user-contents"
@@ -54,7 +55,8 @@ export const SiteLayout: React.FC<SiteLayoutProps> = ({
   const subscription = useGetSubscription(domainOrSubdomain)
   const [{ isLiked }] = useCheckLike({ pageId: page.data?.id })
   const isMint = useCheckMint(page.data?.id)
-
+  useDarkMode()
+  
   useEffect(() => {
     if (site.data) {
       if (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 895ae1a</samp>

Added dark mode support to the site header component. The component now adapts to the user's or system's preferred color scheme using the `useDarkMode` hook.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 895ae1a</samp>

> _In the shadows of the night, we invoke the `useDarkMode` hook_
> _It adapts to our desire, or the system's gloomy look_
> _We defy the blinding light, we embrace the dark and cool_
> _We are the masters of the site, we control the header's rule_

### WHY
When the site page is first mounted, its light/dark mode does not working.
<img width="988" alt="image" src="https://user-images.githubusercontent.com/98948357/235282125-123e3721-7672-464b-99d3-792b0546e6e4.png">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 895ae1a</samp>

* Import and use `useDarkMode` hook to enable theme switching based on user or system preference ([link](https://github.com/Crossbell-Box/xLog/pull/461/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dR19), [link](https://github.com/Crossbell-Box/xLog/pull/461/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dR140))
* Add `useDarkMode` hook to `src/components/site/SiteHeader.tsx`, which renders the site's logo, navigation, and search bar ([link](https://github.com/Crossbell-Box/xLog/pull/461/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dR19), [link](https://github.com/Crossbell-Box/xLog/pull/461/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dR140))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
