### PR TITLE
fix: avatar height not correct on mobile device

### DIFF
--- a/src/components/ui/Avatar.tsx
+++ b/src/components/ui/Avatar.tsx
@@ -65,7 +65,7 @@ export const Avatar: React.FC<
       }}
     >
       <Image
-        className="overflow-hidden object-cover"
+        className="h-full overflow-hidden object-cover"
         src={image}
         width={size}
         height={size}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b05697b</samp>

Fixed a bug in the `Avatar` component that caused some images to look wrong. Added the `h-full` class to the `Image` component in `src/components/ui/Avatar.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b05697b</samp>

> _`h-full` for image_
> _fills the avatar's height_
> _no more cropping bugs_

### WHY
On mobile devices, the avatar is being cut off when the aspect ratio is not 1:1.

![IMG_1003](https://user-images.githubusercontent.com/4584859/235300423-e3821b21-dce4-4027-8e6a-02bce18c558c.jpg)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b05697b</samp>

* Fix image cropping bug in avatar component by adding `h-full` class to `Image` ([link](https://github.com/Crossbell-Box/xLog/pull/462/files?diff=unified&w=0#diff-c76a9998d3c7ee55bf87ec2740e108ad6a8e4ee5c279868232a95516e3230629L68-R68))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
