### PR TITLE
chore: remove axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@urql/core": "4.0.7",
     "ahooks": "^3.7.6",
     "aplayer-react": "^1.1.0",
-    "axios": "1.4.0",
     "canvas-confetti": "^1.6.0",
     "chroma-js": "^2.4.2",
     "clsx": "1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,9 +100,6 @@ dependencies:
   aplayer-react:
     specifier: ^1.1.0
     version: 1.1.0(react@18.2.0)
-  axios:
-    specifier: 1.4.0
-    version: 1.4.0
   canvas-confetti:
     specifier: ^1.6.0
     version: 1.6.0
@@ -162,7 +159,7 @@ dependencies:
     version: 0.16.7
   langchain:
     specifier: ^0.0.66
-    version: 0.0.66(axios@1.4.0)
+    version: 0.0.66
   lottie-react:
     specifier: ^2.4.0
     version: 2.4.0(react-dom@18.2.0)(react@18.2.0)
@@ -9593,7 +9590,7 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /langchain@0.0.66(axios@1.4.0):
+  /langchain@0.0.66:
     resolution: {integrity: sha512-HsVdXFDp2+YB12tvpMFOK6kIXaLvFzJKQUzitr5VEamhZCFUoojZgcS7ckRjxJIv+aVWbEzCi3KJI/2kPKsMkA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -9688,7 +9685,6 @@ packages:
     dependencies:
       '@anthropic-ai/sdk': 0.4.3
       '@dqbd/tiktoken': 1.0.7
-      axios: 1.4.0
       binary-extensions: 2.2.0
       browser-or-node: 2.1.1
       expr-eval: 2.0.2

--- a/src/components/ui/UniMedia.tsx
+++ b/src/components/ui/UniMedia.tsx
@@ -1,4 +1,3 @@
-import axios from "axios"
 import React, { useState } from "react"
 
 import { Image } from "~/components/ui/Image"
@@ -16,11 +15,13 @@ export const UniMedia: React.FC<{
     const src = e.target.getAttribute("original-src")
     if (src && !errorHandled) {
       try {
-        const result = await axios({
-          url: src.replace(IPFS_GATEWAY, "https://gateway.ipfs.io/ipfs/"),
-          method: "HEAD",
-        })
-        setType(result.headers["content-type"])
+        const response = await fetch(
+          src.replace(IPFS_GATEWAY, "https://gateway.ipfs.io/ipfs/"),
+          {
+            method: "HEAD",
+          },
+        )
+        setType(response.headers.get("content-type") ?? "")
         setErrorHandled(true)
       } catch (error) {}
     }

--- a/src/lib/upload-file.ts
+++ b/src/lib/upload-file.ts
@@ -1,19 +1,12 @@
-import axios from "axios"
-
 export const UploadFile = async (blob: Blob) => {
   const formData = new FormData()
   formData.append("file", blob)
 
-  const res = await axios.post(
+  const response = await fetch(
     "https://ipfs-relay.crossbell.io/upload?gnfd=t",
-    formData,
-    {
-      headers: {
-        "Content-Type": "multipart/form-data",
-      },
-    },
+    { method: "POST", body: formData },
   )
   return {
-    key: res.data.url,
+    key: (await response.json()).url,
   }
 }

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -1,4 +1,3 @@
-import axios from "axios"
 import { NoteMetadata } from "crossbell.js"
 import type { Contract } from "crossbell.js"
 import type Unidata from "unidata.js"
@@ -345,14 +344,14 @@ export async function getPage<TRender extends boolean = false>(
   if (!mustLocal) {
     // on-chain page
     if (!input.pageId) {
-      const slug2Id = (
-        await axios.get("/api/slug2id", {
-          params: {
-            handle: input.site,
-            slug: input.page,
-          },
-        })
-      ).data
+      if (!input.site || !input.page) return null
+      const response = await fetch(
+        `/api/slug2id?${new URLSearchParams({
+          handle: input.site,
+          slug: input.page,
+        }).toString()}`,
+      )
+      const slug2Id = (await response.json()).data
       if (!slug2Id?.noteId) {
         return null
       }

--- a/src/models/page.model.ts
+++ b/src/models/page.model.ts
@@ -351,7 +351,7 @@ export async function getPage<TRender extends boolean = false>(
           slug: input.page,
         }).toString()}`,
       )
-      const slug2Id = (await response.json()).data
+      const slug2Id = await response.json()
       if (!slug2Id?.noteId) {
         return null
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad2d70e</samp>

This pull request removes the `axios` library from the project and replaces it with the native fetch API for making HTTP requests. This reduces the project dependencies, simplifies the code, and improves the compatibility with IPFS. The pull request affects the `pnpm-lock.yaml` file and several files in the `src` folder.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ad2d70e</samp>

> _Oh we're the brave developers of the `langchain` crew_
> _We don't need no `axios` to make our requests go through_
> _We use the native `fetch` API and simplify our code_
> _And we check for nulls and errors as we sail the IPFS node_

### WHY

axios is not very useful in modern network technologies, and its size is also quite large. replacing it with fetch will reduce the bundler size.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad2d70e</samp>

*  Remove axios dependency and references from the project ([link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL103-L105), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL165-R162), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9596-R9593), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL9691), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-f4d932c60075f2ab208b12cf771a3ff68a1f22688e7e03c7dbcd65c82ca49792L1), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-33703f17aa564b3fcd73bc6e2105a297370db462e5dc992c284e337905e3fed0L1))
*  Replace axios with native fetch API for making HTTP requests in `UniMedia.tsx`, `upload-file.ts`, and `page.model.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-f4d932c60075f2ab208b12cf771a3ff68a1f22688e7e03c7dbcd65c82ca49792L19-R24), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-8e5b7f1ac7499dd1ce97f0cabf0b05c83bdea2a41fd891cbaa7da263967c5978L1-R10), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-33703f17aa564b3fcd73bc6e2105a297370db462e5dc992c284e337905e3fed0L348-R354))
*  Handle null or undefined cases for content-type header and input parameters using nullish coalescing operator and early return in `UniMedia.tsx` and `page.model.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-f4d932c60075f2ab208b12cf771a3ff68a1f22688e7e03c7dbcd65c82ca49792L19-R24), [link](https://github.com/Crossbell-Box/xLog/pull/469/files?diff=unified&w=0#diff-33703f17aa564b3fcd73bc6e2105a297370db462e5dc992c284e337905e3fed0L348-R354))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
