### PR TITLE
feat: add banner mask

### DIFF
--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -178,7 +178,7 @@ export const SiteHeader: React.FC<{
   }, [bannerRef, avatarRef, isDark])
 
   return (
-    <header className="xlog-header border-b border-zinc-100 relative">
+    <header className="xlog-header border-b border-zinc-100 relative max-w-[100vw] overflow-hidden">
       {averageColor && (
         <style jsx global>{`
           :root {
@@ -334,7 +334,15 @@ export const SiteHeader: React.FC<{
             </div>
           </div>
         </div>
-        <div className="text-gray-500 flex items-center justify-between w-full mt-auto">
+        <div className="xlog-site-navigation__root text-gray-500 flex items-center justify-between w-full mt-auto relative">
+          <div
+            className="xlog-site-navigation__mask before:inset-0 before:bg-[var(--auto-theme-color)] before:opacity-30 before:absolute before:left-[-100vw] before:right-[-100vw]"
+            style={
+              {
+                "--auto-theme-color": autoThemeColor,
+              } as any
+            }
+          />
           <div className="xlog-site-navigation flex items-center space-x-5 min-w-0 overflow-x-auto text-sm sm:text-base">
             {leftLinks.map((link, i) => {
               return <HeaderLink link={link} key={`${link.label}${i}`} />

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -336,7 +336,7 @@ export const SiteHeader: React.FC<{
         </div>
         <div className="xlog-site-navigation__root text-gray-500 flex items-center justify-between w-full mt-auto relative">
           {!!autoThemeColor && (
-            <div className="xlog-site-navigation__mask before:inset-0 before:bg-gray-100 before:opacity-30 before:absolute before:left-[-100vw] before:right-[-100vw]" />
+            <div className="xlog-site-navigation__mask before:inset-0 before:bg-gray-800 before:backdrop-blur-md before:opacity-30 before:absolute before:left-[-100vw] before:right-[-100vw]" />
           )}
           <div className="xlog-site-navigation flex items-center space-x-5 min-w-0 overflow-x-auto text-sm sm:text-base">
             {leftLinks.map((link, i) => {

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -336,14 +336,7 @@ export const SiteHeader: React.FC<{
         </div>
         <div className="xlog-site-navigation__root text-gray-500 flex items-center justify-between w-full mt-auto relative">
           {!!autoThemeColor && (
-            <div
-              className="xlog-site-navigation__mask before:inset-0 before:bg-[var(--auto-theme-color)] before:opacity-30 before:absolute before:left-[-100vw] before:right-[-100vw]"
-              style={
-                {
-                  "--auto-theme-color": autoThemeColor,
-                } as any
-              }
-            />
+            <div className="xlog-site-navigation__mask before:inset-0 before:bg-gray-100 before:opacity-30 before:absolute before:left-[-100vw] before:right-[-100vw]" />
           )}
           <div className="xlog-site-navigation flex items-center space-x-5 min-w-0 overflow-x-auto text-sm sm:text-base">
             {leftLinks.map((link, i) => {

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -335,14 +335,16 @@ export const SiteHeader: React.FC<{
           </div>
         </div>
         <div className="xlog-site-navigation__root text-gray-500 flex items-center justify-between w-full mt-auto relative">
-          <div
-            className="xlog-site-navigation__mask before:inset-0 before:bg-[var(--auto-theme-color)] before:opacity-30 before:absolute before:left-[-100vw] before:right-[-100vw]"
-            style={
-              {
-                "--auto-theme-color": autoThemeColor,
-              } as any
-            }
-          />
+          {!!autoThemeColor && (
+            <div
+              className="xlog-site-navigation__mask before:inset-0 before:bg-[var(--auto-theme-color)] before:opacity-30 before:absolute before:left-[-100vw] before:right-[-100vw]"
+              style={
+                {
+                  "--auto-theme-color": autoThemeColor,
+                } as any
+              }
+            />
+          )}
           <div className="xlog-site-navigation flex items-center space-x-5 min-w-0 overflow-x-auto text-sm sm:text-base">
             {leftLinks.map((link, i) => {
               return <HeaderLink link={link} key={`${link.label}${i}`} />

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -7,6 +7,7 @@
     @apply text-zinc-800;
     @apply fill-zinc-800;
     font-family: var(--font-fans);
+    overflow: overlay;
   }
 
   input,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc4f1ab</samp>

Improved the site header component and added a custom CSS rule. The site header now adapts to different screen sizes and has a better visual design. The `overflow: overlay` rule allows customizing the scrollbars for the navigation links.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cc4f1ab</samp>

> _We defy the default configuration_
> _We unleash the custom scrollbars_
> _We mask the overflow with gradient_
> _We adapt the colors of the stars_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cc4f1ab</samp>

*  Prevent horizontal scrolling and overflow issues on small screens by adding `max-w-[100vw]` and `overflow-hidden` classes to the header element ([link](https://github.com/Crossbell-Box/xLog/pull/471/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL181-R181))
* Create a gradient mask effect for the site navigation links by adding `xlog-site-navigation__root` and `xlog-site-navigation__mask` elements ([link](https://github.com/Crossbell-Box/xLog/pull/471/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL337-R345))
* Use a CSS variable `--auto-theme-color` to match the mask color to the average color of the site logo ([link](https://github.com/Crossbell-Box/xLog/pull/471/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL337-R345))
* Extend the mask gradient beyond the viewport edges using pseudo-elements ([link](https://github.com/Crossbell-Box/xLog/pull/471/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL337-R345))
* Enable custom scrollbars for the site navigation links by adding `overflow: overlay` rule to the `src/css/tailwind.css` file ([link](https://github.com/Crossbell-Box/xLog/pull/471/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R10))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
