### PR TITLE
fix: my xlog link invalid when no character has been minted by user

### DIFF
--- a/src/components/common/ConnectButton.tsx
+++ b/src/components/common/ConnectButton.tsx
@@ -117,14 +117,14 @@ export const ConnectButton: React.FC<{
           icon: "icon-[mingcute--home-1-line]",
           label: t("My xLog") || "",
           url: getSiteLink({
-            subdomain: userSites.data?.[0]?.username || "",
+            subdomain: userSites.data?.[0]?.username,
           }),
         }
       : {
           icon: "icon-[mingcute--home-1-line]",
           label: t("My xLog") || "",
           url: getSiteLink({
-            subdomain: userSites.data?.[0]?.username || "",
+            subdomain: "",
           }),
           onClick: () => walletMintNewCharacterModal.show(),
         },

--- a/src/components/common/ConnectButton.tsx
+++ b/src/components/common/ConnectButton.tsx
@@ -12,6 +12,7 @@ import {
   useOpSignSettingsModal,
   useSelectCharactersModal,
   useUpgradeEmailAccountModal,
+  useWalletMintNewCharacterModal,
 } from "@crossbell/connect-kit"
 import {
   useNotifications,
@@ -87,6 +88,7 @@ export const ConnectButton: React.FC<{
   const opSignSettingsModal = useOpSignSettingsModal()
   const upgradeAccountModal = useUpgradeEmailAccountModal()
   const selectCharactersModal = useSelectCharactersModal()
+  const walletMintNewCharacterModal = useWalletMintNewCharacterModal()
 
   const userSites = useAccountSites()
 
@@ -110,13 +112,28 @@ export const ConnectButton: React.FC<{
   }, [balance])
 
   const dropdownLinks: HeaderLinkType[] = [
-    {
-      icon: "icon-[mingcute--home-1-line]",
-      label: t("My xLog") || "",
-      url: getSiteLink({
-        subdomain: userSites.data?.[0]?.username || "",
-      }),
-    },
+    userSites.data?.[0]?.username
+      ? {
+          icon: "icon-[mingcute--home-1-line]",
+          label: t("My xLog") || "",
+          url: getSiteLink({
+            subdomain: userSites.data?.[0]?.username || "",
+          }),
+        }
+      : {
+          icon: "icon-[mingcute--home-1-line]",
+          label: t("My xLog") || "",
+          url: getSiteLink({
+            subdomain: userSites.data?.[0]?.username || "",
+          }),
+          onClick: () => {
+            if (!userSites.data?.[0]?.username) {
+              walletMintNewCharacterModal.show()
+            } else {
+              return null
+            }
+          },
+        },
     {
       icon: "icon-[mingcute--grid-line]",
       label: t("Dashboard") || "",

--- a/src/components/common/ConnectButton.tsx
+++ b/src/components/common/ConnectButton.tsx
@@ -126,13 +126,7 @@ export const ConnectButton: React.FC<{
           url: getSiteLink({
             subdomain: userSites.data?.[0]?.username || "",
           }),
-          onClick: () => {
-            if (!userSites.data?.[0]?.username) {
-              walletMintNewCharacterModal.show()
-            } else {
-              return null
-            }
-          },
+          onClick: () => walletMintNewCharacterModal.show(),
         },
     {
       icon: "icon-[mingcute--grid-line]",

--- a/src/components/common/ConnectButton.tsx
+++ b/src/components/common/ConnectButton.tsx
@@ -123,9 +123,6 @@ export const ConnectButton: React.FC<{
       : {
           icon: "icon-[mingcute--home-1-line]",
           label: t("My xLog") || "",
-          url: getSiteLink({
-            subdomain: "",
-          }),
           onClick: () => walletMintNewCharacterModal.show(),
         },
     {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15a3896</samp>

Added a feature to mint a new character for xLog users. Updated `ConnectButton.tsx` to handle the minting logic and UI.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 15a3896</samp>

> _`My xLog` link changed_
> _Mint a new character now_
> _Modal or site? Cut!_

### WHY
<!-- author to complete -->

The My xLog button points to `https://.xlog.app` when the current user has not minted a character.

<img width="752" alt="Screenshot 2023-04-30 at 23 50 49" src="https://user-images.githubusercontent.com/34052227/235379090-84393956-a27d-4f46-8b63-93836e469218.png">

The behavior after the fix is when a user with no character clicks the My xLog button, it prompts the mint window.

<img width="688" alt="Screenshot 2023-05-01 at 00 34 05" src="https://user-images.githubusercontent.com/34052227/235379251-702d1a2e-f751-4dbf-9f50-9a92fa54d33f.png">


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 15a3896</samp>

*  Import and use `useWalletMintNewCharacterModal` hook to provide a modal component for minting a new character for the user's xLog site ([link](https://github.com/Crossbell-Box/xLog/pull/472/files?diff=unified&w=0#diff-bcff1bcc3cdc6f01659817ebd75808cbbca143eeed52b41ab365fbba64b491f6R15), [link](https://github.com/Crossbell-Box/xLog/pull/472/files?diff=unified&w=0#diff-bcff1bcc3cdc6f01659817ebd75808cbbca143eeed52b41ab365fbba64b491f6R91))
*  Modify `dropdownLinks` array to conditionally render a different link for the "My xLog" option based on the user's username ([link](https://github.com/Crossbell-Box/xLog/pull/472/files?diff=unified&w=0#diff-bcff1bcc3cdc6f01659817ebd75808cbbca143eeed52b41ab365fbba64b491f6L113-R131))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.

https://real-chell.xlog.app/
Chell#0957
