### PR TITLE
feat: add Umami Cloud Analysis

### DIFF
--- a/public/locales/ja/dashboard.json
+++ b/public/locales/ja/dashboard.json
@@ -85,6 +85,7 @@
   "Name": "名前",
   "Description": "説明",
   "Integrate Google Analytics": "Google Analytics と紐付けします。Measurement ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
+  "Integrate Umami Cloud Analytics": "Umami Cloud Analytics と紐付けします。Website ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
   "Save": "保存",
   "Tips": "ヒント",
   "social tips": {

--- a/public/locales/zh-TW/dashboard.json
+++ b/public/locales/zh-TW/dashboard.json
@@ -90,6 +90,7 @@
     "Name": "名稱",
     "Description": "自我介紹",
     "Integrate Google Analytics": "將 Google Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Measurement ID。",
+    "Integrate Umami Cloud Analytics": "將 Umami Cloud Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Website ID。",
     "Save": "儲存",
     "Tips": "提示",
     "social tips": {

--- a/public/locales/zh/dashboard.json
+++ b/public/locales/zh/dashboard.json
@@ -91,6 +91,7 @@
   "Name": "名称",
   "Description": "描述",
   "Integrate Google Analytics": "将 Google Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Measurement ID。",
+  "Integrate Umami Cloud Analytics": "将 Umami Cloud Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Website ID。",
   "Save": "保存",
   "Tips": "提示",
   "social tips": {

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -89,6 +89,16 @@ export const SiteFooter: React.FC<{
           </Script>
         </div>
       )}
+      {site?.metadata?.content?.ua && (
+        <div className="xlog-umami-analytics">
+          <Script
+            id="umami-analytics" strategy="afterInteractive"
+            async src="https://analytics.umami.is/script.js"
+            data-website-id={`${site.metadata?.content?.ua}`}
+          >
+          </Script>
+        </div>
+      )}
     </>
   )
 }

--- a/src/lib/expand-unit.ts
+++ b/src/lib/expand-unit.ts
@@ -103,6 +103,10 @@ export const expandCrossbellCharacter = (site: CharacterEntity) => {
     (expandedCharacter.metadata?.content?.attributes?.find(
       (a: any) => a.trait_type === "xlog_ga",
     )?.value as string) || ""
+  expandedCharacter.metadata.content.ua =
+    (expandedCharacter.metadata?.content?.attributes?.find(
+      (a: any) => a.trait_type === "xlog_ua",
+    )?.value as string) || ""
   expandedCharacter.metadata.content.custom_domain =
     (expandedCharacter.metadata?.content?.attributes?.find(
       (a: any) => a.trait_type === "xlog_custom_domain",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -101,6 +101,7 @@ export type ExpandedCharacter = CharacterEntity & {
       navigation?: SiteNavigationItem[]
       css?: string
       ga?: string
+      ua?: string
       custom_domain?: string
     }
   }

--- a/src/models/site.model.ts
+++ b/src/models/site.model.ts
@@ -106,6 +106,7 @@ export async function updateSite(
     navigation?: SiteNavigationItem[]
     css?: string
     ga?: string
+    ua?: string
     custom_domain?: string
     banner?: {
       address: string
@@ -141,6 +142,7 @@ export async function updateSite(
       ...((payload.navigation !== undefined ||
         payload.css !== undefined ||
         payload.ga !== undefined ||
+        payload.ua !== undefined ||
         payload.custom_domain !== undefined) && {
         attributes: [
           ...(payload.navigation !== undefined
@@ -164,6 +166,14 @@ export async function updateSite(
                 {
                   trait_type: "xlog_ga",
                   value: payload.ga,
+                },
+              ]
+            : []),
+          ...(payload.ua !== undefined
+            ? [
+                {
+                  trait_type: "xlog_ua",
+                  value: payload.ua,
                 },
               ]
             : []),

--- a/src/pages/dashboard/[subdomain]/settings/general.tsx
+++ b/src/pages/dashboard/[subdomain]/settings/general.tsx
@@ -45,6 +45,7 @@ export default function SiteSettingsGeneralPage() {
       name: "",
       description: "",
       ga: "",
+      ua: "",
     } as {
       icon: string
       banner?: {
@@ -54,6 +55,7 @@ export default function SiteSettingsGeneralPage() {
       name: string
       description: string
       ga: string
+      ua: string
     },
   })
 
@@ -65,6 +67,7 @@ export default function SiteSettingsGeneralPage() {
       name: values.name,
       description: values.description,
       ga: values.ga,
+      ua: values.ua,
     })
   })
 
@@ -105,6 +108,8 @@ export default function SiteSettingsGeneralPage() {
         form.setValue("description", site.data.metadata?.content?.bio || "")
       !form.getValues("ga") &&
         form.setValue("ga", site.data.metadata?.content?.ga || "")
+      !form.getValues("ua") &&
+        form.setValue("ua", site.data.metadata?.content?.ua || "")
     }
   }, [site.data, form])
 
@@ -206,6 +211,28 @@ export default function SiteSettingsGeneralPage() {
                     here
                   </UniLink>{" "}
                   to find your Measurement ID.
+                </Trans>
+              </p>
+            }
+          />
+        </div>
+        <div className="mt-5">
+          <Input
+            id="ua"
+            {...form.register("ua")}
+            label="Umami Cloud Analytics"
+            help={
+              <p>
+                <Trans i18nKey="Integrate Umami Cloud Analytics" ns="dashboard">
+                  Integrate Umami Cloud Analytics into your site. You can follow the
+                  instructions{" "}
+                  <UniLink
+                    className="underline"
+                    href="https://umami.is/docs/collect-data"
+                  >
+                    here
+                  </UniLink>{" "}
+                  to find your Website ID.
                 </Trans>
               </p>
             }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b79cc1f</samp>

This pull request adds Umami Cloud Analytics integration to the site settings and the site footer. It allows users to enter and update their `ua` field in the settings form, and renders a script tag with their `ua` value in the footer. It also updates the site model, the site object, and the profile type to handle the `ua` property.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b79cc1f</samp>

> _If you want to track your site's traffic_
> _You can use Umami, it's fantastic_
> _Just enter your `ua`_
> _In the settings area_
> _And the script will load it automatic_

### WHY
Close #475 .
![image](https://user-images.githubusercontent.com/57583560/235452812-cf778172-493f-4f3d-a6c1-f66767ceb9d2.png)
![image](https://user-images.githubusercontent.com/57583560/235452876-4ea96d18-b289-40cb-991e-1137cd6211cd.png)


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b79cc1f</samp>

*  Add Umami analytics integration to the site settings form and the site footer ([link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-765d257cdb9e99b90862bdf509d92d60910659262e97a25f78e2c48a44847bcfR86-R95), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-0802612f2ebfab23d2656fc2189271c4fef6451452a2bd7dacc8d8bcfe11e2e8R70-R72), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R123), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R252-R259), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR48), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR58), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR70), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR104), [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR212-R233))
  * Retrieve the site's Umami website ID from the metadata attributes and store it in the `ua` property of the `site` object (`src/lib/expand-unit.ts`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-0802612f2ebfab23d2656fc2189271c4fef6451452a2bd7dacc8d8bcfe11e2e8R70-R72))
  * Add the optional `ua` property to the `Profile` type to represent the Umami website ID in the profile data (`src/lib/types.ts`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R123))
  * Update the site's metadata attributes to include or exclude the Umami website ID depending on the payload in the `updateSite` method (`src/models/site.model.ts`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R252-R259))
  * Initialize the `ua` property with an empty string in the `initialValues` object for the site settings form (`src/pages/dashboard/[subdomain]/settings/general.tsx`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR48))
  * Add the `ua` property to the `FormValues` type with a string annotation for the site settings form (`src/pages/dashboard/[subdomain]/settings/general.tsx`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR58))
  * Include the `ua` property in the `values` object for the API submission of the updated site data (`src/pages/dashboard/[subdomain]/settings/general.tsx`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR70))
  * Pre-fill the `ua` value in the form with the site's Umami website ID if it exists using the `form.setValue` method (`src/pages/dashboard/[subdomain]/settings/general.tsx`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR104))
  * Add a new input component for the Umami website ID field in the site settings form with an id of `ua`, a label of `Umami Cloud Analytics`, and a help text (`src/pages/dashboard/[subdomain]/settings/general.tsx`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-bef29046a2d8aa4c61dfa50cfdfd3331b60ca1c70a1a8b7b90846fc5e3c2605eR212-R233))
  * Render a script tag that loads the Umami analytics script from a CDN in the site footer, using the site's Umami website ID as a data attribute, if it exists (`src/components/site/SiteFooter.tsx`, [link](https://github.com/Crossbell-Box/xLog/pull/476/files?diff=unified&w=0#diff-765d257cdb9e99b90862bdf509d92d60910659262e97a25f78e2c48a44847bcfR86-R95))

### CLAIM REWARDS
<!-- author to complete -->
xLog ID: `kev1n8w-3605`
Discord ID: `Kevin Williams#4900`
