### PR TITLE
perf(a11y): add focus-visible outline to posts list

### DIFF
--- a/src/components/site/SiteHome.tsx
+++ b/src/components/site/SiteHome.tsx
@@ -48,7 +48,7 @@ export const SiteHome: React.FC<{
                 <Link
                   key={post.transactionHash}
                   href={getSlugUrl(`/${post.metadata?.content?.slug}`)}
-                  className="xlog-post sm:hover:bg-hover bg-white transition-all px-5 py-7 -mx-5 first:-mt-5 sm:rounded-xl flex flex-col sm:flex-row items-center"
+                  className="xlog-post focus-visible:outline focus-visible:outline-accent sm:hover:bg-hover bg-white transition-colors px-5 py-7 -mx-5 first:-mt-5 sm:rounded-xl flex flex-col sm:flex-row items-center"
                   suppressHydrationWarning
                 >
                   <div className="flex-1 flex justify-center flex-col w-full min-w-0">


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ff18342</samp>

Improved keyboard focus feedback for `xlog-post` component. Added outline styles and adjusted transitions in `SiteHome.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ff18342</samp>

> _`xlog-post` outlined_
> _keyboard focus visible_
> _winter of web a11y_

### WHY

Make it easier for users navigating with keyboard to recognize the focused item on the post list

https://user-images.githubusercontent.com/8225666/235830592-fff3011e-66a2-4b2b-a377-ed9f88c83558.mov



### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ff18342</samp>

*  Add visible outline to `xlog-post` element when focused with keyboard for better accessibility and user feedback ([link](https://github.com/Crossbell-Box/xLog/pull/481/files?diff=unified&w=0#diff-49224ea7427bd8134c85c03395e94ae9c4d288f85cda1ad181a9bf7d5d6131aaL51-R51))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
