### PR TITLE
fix: CharacterCard fetch every open

### DIFF
--- a/src/components/common/CharacterCard.tsx
+++ b/src/components/common/CharacterCard.tsx
@@ -1,14 +1,12 @@
 import { useTranslation } from "next-i18next"
-import { useEffect, useState } from "react"
 
 import { FollowingButton } from "~/components/common/FollowingButton"
 import { FollowingCount } from "~/components/common/FollowingCount"
 import { Titles } from "~/components/common/Titles"
 import { Avatar } from "~/components/ui/Avatar"
 import { useDate } from "~/hooks/useDate"
-import type { ExpandedCharacter } from "~/lib/types"
 import { cn } from "~/lib/utils"
-import * as siteModel from "~/models/site.model"
+import { useGetSite, useGetSiteByAddress } from "~/queries/site"
 
 export const CharacterCard: React.FC<{
   siteId?: string
@@ -27,25 +25,30 @@ export const CharacterCard: React.FC<{
   simple,
   style,
 }) => {
-  const [firstOpen, setFirstOpen] = useState("")
-  const [site, setSite] = useState<ExpandedCharacter>()
+  // const [firstOpen, setFirstOpen] = useState("")
+  // const [site, setSite] = useState<ExpandedCharacter>()
   const date = useDate()
   const { t } = useTranslation("common")
 
-  useEffect(() => {
-    if (open && (firstOpen !== (siteId || address) || !site)) {
-      if (siteId || address) {
-        setFirstOpen(siteId || address || "")
-        if (siteId) {
-          siteModel.getSite(siteId).then((site) => setSite(site))
-        } else if (address) {
-          siteModel.getSiteByAddress(address).then((site) => setSite(site))
-        }
-      } else {
-        setSite(undefined)
-      }
-    }
-  }, [open, firstOpen, siteId, address, site])
+  const { data: siteData } = useGetSite(siteId)
+  const { data: addressData } = useGetSiteByAddress(address)
+
+  const site = siteData ? siteData : addressData
+
+  // useEffect(() => {
+  //   if (open && (firstOpen !== (siteId || address) || !site)) {
+  //     if (siteId || address) {
+  //       setFirstOpen(siteId || address || "")
+  //       if (siteId) {
+  //         siteModel.getSite(siteId).then((site) => setSite(site))
+  //       } else if (address) {
+  //         siteModel.getSiteByAddress(address).then((site) => setSite(site))
+  //       }
+  //     } else {
+  //       setSite(undefined)
+  //     }
+  //   }
+  // }, [open, firstOpen, siteId, address, site])
 
   return (
     <span

--- a/src/components/common/CharacterCard.tsx
+++ b/src/components/common/CharacterCard.tsx
@@ -6,7 +6,7 @@ import { Titles } from "~/components/common/Titles"
 import { Avatar } from "~/components/ui/Avatar"
 import { useDate } from "~/hooks/useDate"
 import { cn } from "~/lib/utils"
-import { useGetSite, useGetSiteByAddress } from "~/queries/site"
+import { useGetCharacterCard } from "~/queries/site"
 
 export const CharacterCard: React.FC<{
   siteId?: string
@@ -28,10 +28,11 @@ export const CharacterCard: React.FC<{
   const date = useDate()
   const { t } = useTranslation("common")
 
-  const { data: dataBySite } = useGetSite(siteId)
-  const { data: dataByAddress } = useGetSiteByAddress(address)
-
-  const site = dataBySite ? dataBySite : dataByAddress
+  const { data: site } = useGetCharacterCard({
+    siteId,
+    address,
+    enabled: open || false,
+  })
 
   return (
     <span

--- a/src/components/common/CharacterCard.tsx
+++ b/src/components/common/CharacterCard.tsx
@@ -25,30 +25,13 @@ export const CharacterCard: React.FC<{
   simple,
   style,
 }) => {
-  // const [firstOpen, setFirstOpen] = useState("")
-  // const [site, setSite] = useState<ExpandedCharacter>()
   const date = useDate()
   const { t } = useTranslation("common")
 
-  const { data: siteData } = useGetSite(siteId)
-  const { data: addressData } = useGetSiteByAddress(address)
+  const { data: dataBySite } = useGetSite(siteId)
+  const { data: dataByAddress } = useGetSiteByAddress(address)
 
-  const site = siteData ? siteData : addressData
-
-  // useEffect(() => {
-  //   if (open && (firstOpen !== (siteId || address) || !site)) {
-  //     if (siteId || address) {
-  //       setFirstOpen(siteId || address || "")
-  //       if (siteId) {
-  //         siteModel.getSite(siteId).then((site) => setSite(site))
-  //       } else if (address) {
-  //         siteModel.getSiteByAddress(address).then((site) => setSite(site))
-  //       }
-  //     } else {
-  //       setSite(undefined)
-  //     }
-  //   }
-  // }, [open, firstOpen, siteId, address, site])
+  const site = dataBySite ? dataBySite : dataByAddress
 
   return (
     <span

--- a/src/queries/site.ts
+++ b/src/queries/site.ts
@@ -402,11 +402,28 @@ export const useGetGreenfieldId = (cid?: string) => {
   })
 }
 
-export const useGetSiteByAddress = (address?: string) => {
-  return useQuery(["useGetSiteByAddress", address], async () => {
-    if (!address) {
-      return null
-    }
-    return siteModel.getSiteByAddress(address)
-  })
+export const useGetCharacterCard = ({
+  siteId,
+  address,
+  enabled,
+}: {
+  siteId?: string
+  address?: string
+  enabled: boolean
+}) => {
+  return useQuery(
+    ["useGetCharacterCard", { siteId, address }],
+    async () => {
+      if (siteId) {
+        return siteModel.getSite(siteId)
+      } else if (address) {
+        return siteModel.getSiteByAddress(address)
+      } else {
+        return null
+      }
+    },
+    {
+      enabled,
+    },
+  )
 }

--- a/src/queries/site.ts
+++ b/src/queries/site.ts
@@ -401,3 +401,12 @@ export const useGetGreenfieldId = (cid?: string) => {
     return siteModel.getGreenfieldId(cid)
   })
 }
+
+export const useGetSiteByAddress = (address?: string) => {
+  return useQuery(["useGetSiteByAddress", address], async () => {
+    if (!address) {
+      return null
+    }
+    return siteModel.getSiteByAddress(address)
+  })
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 509ab4e</samp>

Refactored the `CharacterCard` component and added a new `useGetSiteByAddress` hook. The changes improve performance and readability by using `react-query` for fetching and caching site data.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 509ab4e</samp>

> _Sing to me, O Muse, of the skillful coder who refactored_
> _The `CharacterCard` component, using `react-query` hooks_
> _To fetch and cache the site data, as swift as Hermes' winged sandals_
> _And added the `useGetSiteByAddress` hook, a clever tool like Hephaestus' forge_

### WHY

firstOpen state will always be "" first

https://user-images.githubusercontent.com/4584859/235961463-cccf2827-c63c-4948-a9c9-16e13c772b45.mov



### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 509ab4e</samp>

*  Refactor `CharacterCard` component to use `react-query` hooks instead of local state ([link](https://github.com/Crossbell-Box/xLog/pull/482/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cL2), [link](https://github.com/Crossbell-Box/xLog/pull/482/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cL9-R9), [link](https://github.com/Crossbell-Box/xLog/pull/482/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cL30-R35))
* Add `useGetSiteByAddress` hook to `src/queries/site.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/482/files?diff=unified&w=0#diff-54c8e50208a8d4d4ce7a68f5fbe42cd0f2110003d51ded9e83bc4bc2ef036479R404-R412))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
