### PR TITLE
feat: discard changes

### DIFF
--- a/public/locales/ja/dashboard.json
+++ b/public/locales/ja/dashboard.json
@@ -60,6 +60,7 @@
   "Preview": "プレビュー",
   "Publish": "公開",
   "Update": "更新",
+  "Discard Changes": "変更を破棄",
   "Publish at": "公開日時",
   "This post will be accessible from this time": "この記事は、この時間からアクセス可能になります",
   "This page will be accessible from this time": "このページは、この時間からアクセス可能になります",

--- a/public/locales/zh-TW/dashboard.json
+++ b/public/locales/zh-TW/dashboard.json
@@ -65,6 +65,7 @@
     "Preview": "預覽",
     "Publish": "發布",
     "Update": "更新",
+    "Discard Changes": "捨棄變更",
     "Publish at": "發布時間",
     "This post will be accessible from this time": "此文章將從此時間開始可瀏覽",
     "This page will be accessible from this time": "此頁面將從此時間開始可瀏覽",

--- a/public/locales/zh/dashboard.json
+++ b/public/locales/zh/dashboard.json
@@ -66,6 +66,7 @@
   "Preview": "预览",
   "Publish": "发布",
   "Update": "更新",
+  "Discard Changes": "放弃变更",
   "Publish at": "发布时间",
   "This post will be accessible from this time": "此文章将从此时间开始可访问",
   "This page will be accessible from this time": "此页面将从此时间开始可访问",

--- a/src/components/dashboard/OptionsButton.tsx
+++ b/src/components/dashboard/OptionsButton.tsx
@@ -17,6 +17,8 @@ export const OptionsButton: React.FC<{
   isRendering: boolean
   published: boolean
   isPost: boolean
+  isModified: boolean
+  discardChanges: () => void
 }> = ({
   visibility,
   previewPage,
@@ -26,6 +28,8 @@ export const OptionsButton: React.FC<{
   published,
   propertiesWidget,
   isPost,
+  isModified,
+  discardChanges,
 }) => {
   const { t } = useTranslation("dashboard")
 
@@ -111,6 +115,20 @@ export const OptionsButton: React.FC<{
                         </button>
                       )}
                     </Menu.Item>
+                    {isModified && (
+                      <Menu.Item>
+                        {({ active }) => (
+                          <button
+                            className={`${
+                              active ? "bg-accent text-white" : "text-gray-900"
+                            } group flex w-full items-center rounded-md px-2 py-2 text-sm`}
+                            onClick={discardChanges}
+                          >
+                            {t("Discard Changes")}
+                          </button>
+                        )}
+                      </Menu.Item>
+                    )}
                     {published && (
                       <Menu.Item>
                         {({ active }) => (

--- a/src/components/dashboard/PublishButton.tsx
+++ b/src/components/dashboard/PublishButton.tsx
@@ -12,7 +12,18 @@ export const PublishButton: React.FC<{
   isDisabled: boolean
   twitterShareUrl?: string
   isPost: boolean
-}> = ({ save, published, isSaving, isDisabled, twitterShareUrl, isPost }) => {
+  isModified: boolean
+  discardChanges: () => void
+}> = ({
+  save,
+  discardChanges,
+  published,
+  isSaving,
+  isDisabled,
+  isModified,
+  twitterShareUrl,
+  isPost,
+}) => {
   const [showDropdown, setShowDropdown] = useState(false)
   const dropdownRef = useRef<HTMLDivElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
@@ -70,6 +81,15 @@ export const PublishButton: React.FC<{
                   <i className="icon-[mingcute--twitter-line] mr-1"></i>
                   {t("Share to Twitter")}
                 </button>
+                {isModified && (
+                  <button
+                    className="flex w-full h-8 hover:bg-zinc-100 items-center px-5"
+                    onClick={discardChanges}
+                  >
+                    <i className="icon-[mingcute--delete-back-line] mr-1"></i>
+                    {t("Discard Changes")}
+                  </button>
+                )}
                 <button
                   className="flex w-full h-8 hover:bg-zinc-100 items-center px-5"
                   onClick={() => setDeleteConfirmModalOpen(true)}

--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -508,6 +508,13 @@ export default function SubdomainEditor() {
     />
   )
 
+  const discardChanges = () => {
+    const draftKey = getDraftKey()
+    delStorage(draftKey)
+    // Return back to last page
+    router.back()
+  }
+
   return (
     <>
       <DashboardMain fullWidth>
@@ -540,6 +547,8 @@ export default function SubdomainEditor() {
                     propertiesWidget={extraProperties}
                     previewPage={onPreviewButtonClick}
                     isPost={isPost}
+                    isModified={visibility === PageVisibilityEnum.Modified}
+                    discardChanges={discardChanges}
                   />
                 </div>
               ) : (
@@ -577,6 +586,8 @@ export default function SubdomainEditor() {
                       visibility !== PageVisibilityEnum.Draft
                     }
                     isPost={isPost}
+                    isModified={visibility === PageVisibilityEnum.Modified}
+                    discardChanges={discardChanges}
                   />
                 </div>
               )}

--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -508,12 +508,18 @@ export default function SubdomainEditor() {
     />
   )
 
-  const discardChanges = () => {
-    const draftKey = getDraftKey()
-    delStorage(draftKey)
-    // Return back to last page
-    router.back()
-  }
+  const discardChanges = useCallback(() => {
+    if (draftKey) {
+      delStorage(draftKey)
+      queryClient.invalidateQueries(["getPagesBySite", site.data?.characterId])
+      queryClient.invalidateQueries([
+        "getPage",
+        draftKey.replace(`draft-${site.data?.characterId}-`, ""),
+      ])
+    } else {
+      queryClient.invalidateQueries(["getPage", pageId])
+    }
+  }, [draftKey])
 
   return (
     <>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 28dfeba</samp>

Added a discard changes feature to the dashboard page editor, which lets users undo their modifications and delete their drafts. Modified the `OptionsButton` and `PublishButton` components to receive new props and display a discard button. Updated the `editor.tsx` page component to handle the discard logic and pass the props to the child components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 28dfeba</samp>

> _`OptionsButton` has_
> _discard changes feature now_
> _so does `PublishButton`_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 28dfeba</samp>

*  Add `isModified` and `discardChanges` props to `OptionsButton` and `PublishButton` components to enable discarding unsaved changes ([link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-479ab63058d60b7ddfa9a0fce4a15ee5f72816e67ca5cafb5269aa33aca729acR20-R21), [link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-479ab63058d60b7ddfa9a0fce4a15ee5f72816e67ca5cafb5269aa33aca729acR31-R32), [link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-479ab63058d60b7ddfa9a0fce4a15ee5f72816e67ca5cafb5269aa33aca729acR118-R131), [link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-60cf8e317c83e7b1c51610131301b8476378275bdf0468998027634880d551fcL15-R26), [link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-60cf8e317c83e7b1c51610131301b8476378275bdf0468998027634880d551fcR84-R92), [link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R550-R551), [link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R589-R590))
*  Define `discardChanges` function in `Editor` page component to delete draft from local storage and navigate back to previous page ([link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R511-R517))
*  Pass `isModified` prop to `OptionsButton` and `PublishButton` components based on `visibility` state variable in `Editor` page component ([link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R550-R551), [link](https://github.com/Crossbell-Box/xLog/pull/484/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R589-R590))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
