### PR TITLE
Feat/tag selector

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,4 +1,5 @@
-import { forwardRef } from "react"
+import { forwardRef, useCallback, useMemo } from "react"
+import type { ReactElement } from "react"
 
 import { cn } from "~/lib/utils"
 
@@ -12,6 +13,7 @@ type InputProps<TMultiline extends boolean> = {
   error?: string
   help?: React.ReactNode
   multiline?: TMultiline
+  renderInput?: (props: any) => ReactElement
 } & React.ComponentPropsWithRef<TMultiline extends true ? "textarea" : "input">
 
 export const Input = forwardRef(function Input<
@@ -26,6 +28,7 @@ export const Input = forwardRef(function Input<
     error,
     help,
     multiline,
+    renderInput,
     ...inputProps
   }: InputProps<TMultiline>,
   ref: TMultiline extends true
@@ -34,7 +37,31 @@ export const Input = forwardRef(function Input<
 ) {
   const hasAddon = !!addon
   const hasPrefix = !!prefix
-  const Component = (multiline ? "textarea" : "input") as any
+
+  const inputComponentProps = useMemo(
+    () => ({
+      ...inputProps,
+      ref,
+      className: cn(
+        "input",
+        hasAddon && `has-addon`,
+        hasPrefix && `has-prefix`,
+        isBlock && `is-block`,
+        className,
+      ),
+    }),
+    [className, hasAddon, hasPrefix, inputProps, isBlock, ref],
+  )
+
+  const renderInputComponent = useCallback(() => {
+    if (renderInput) {
+      return renderInput(inputComponentProps)
+    } else if (multiline) {
+      return <textarea {...inputComponentProps} />
+    } else {
+      return <input {...inputComponentProps} />
+    }
+  }, [inputComponentProps, multiline, renderInput])
 
   return (
     <div>
@@ -45,17 +72,7 @@ export const Input = forwardRef(function Input<
             {prefix}
           </span>
         )}
-        <Component
-          {...inputProps}
-          ref={ref as any}
-          className={cn(
-            "input",
-            hasAddon && `has-addon`,
-            hasPrefix && `has-prefix`,
-            isBlock && `is-block`,
-            className,
-          )}
-        />
+        {renderInputComponent()}
         {addon && (
           <span className="flex items-center px-3 text-gray-600 bg-gray-50 h-10 border border-l-0 rounded-r-lg relative -z-10">
             {addon}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -39,17 +39,18 @@ export const Input = forwardRef(function Input<
   const hasPrefix = !!prefix
 
   const inputComponentProps = useMemo(
-    () => ({
-      ...inputProps,
-      ref,
-      className: cn(
-        "input",
-        hasAddon && `has-addon`,
-        hasPrefix && `has-prefix`,
-        isBlock && `is-block`,
-        className,
-      ),
-    }),
+    () =>
+      ({
+        ...inputProps,
+        ref,
+        className: cn(
+          "input",
+          hasAddon && `has-addon`,
+          hasPrefix && `has-prefix`,
+          isBlock && `is-block`,
+          className,
+        ),
+      } as any),
     [className, hasAddon, hasPrefix, inputProps, isBlock, ref],
   )
 

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -13,8 +13,10 @@ type InputProps<TMultiline extends boolean> = {
   error?: string
   help?: React.ReactNode
   multiline?: TMultiline
-  renderInput?: (props: any) => ReactElement
+  renderInput?: (props: Omit<InputProps<false>, "renderInput">) => ReactElement
 } & React.ComponentPropsWithRef<TMultiline extends true ? "textarea" : "input">
+
+export type CustomInputProps = Omit<InputProps<false>, "renderInput">
 
 export const Input = forwardRef(function Input<
   TMultiline extends boolean = false,

--- a/src/components/ui/TagInput.tsx
+++ b/src/components/ui/TagInput.tsx
@@ -10,7 +10,7 @@ import {
 
 import { useEditorState } from "~/hooks/useEdtiorState"
 
-interface Props {
+interface Props extends HTMLInputElement {
   userTags: string[]
 }
 

--- a/src/components/ui/TagInput.tsx
+++ b/src/components/ui/TagInput.tsx
@@ -1,0 +1,121 @@
+import { Fragment, useCallback, useState } from "react"
+
+import { Combobox, Transition } from "@headlessui/react"
+import {
+  CheckIcon,
+  ChevronUpDownIcon,
+  XMarkIcon,
+} from "@heroicons/react/20/solid"
+
+interface Props {
+  userTags: string[]
+}
+
+export function TagInput({ className, userTags }: Props) {
+  const [selected, setSelected] = useState("")
+  const [query, setQuery] = useState("")
+
+  const [tags, setTags] = useState<string[]>([])
+
+  const onComboboxChange = useCallback((value: string) => {
+    setTags((tags) => tags.concat([value]))
+  }, [])
+
+  const onDel = useCallback((value: string) => {
+    setTags((tags) => tags.filter((tag) => tag !== value))
+  }, [])
+
+  const filteredTags =
+    query === ""
+      ? tags
+      : tags.filter((tag) =>
+          tag
+            .toLowerCase()
+            .replace(/\s+/g, "")
+            .includes(query.toLowerCase().replace(/\s+/g, "")),
+        )
+
+  return (
+    <div className="w-full">
+      <div className="flex flex-wrap gap-2 mb-2">
+        {tags.map((tag) => (
+          <div
+            className="text-xs flex items-center font-bold leading-sm px-1 py-1 rounded-md"
+            style={{
+              background: "var(--theme-color)",
+              color: "rgba(var(--tw-colors-i-white), var(--tw-text-opacity))",
+            }}
+            key={tag}
+          >
+            <span>{tag}</span>
+            <XMarkIcon className="h-5 w-5" onClick={() => onDel(tag)} />
+          </div>
+        ))}
+      </div>
+      <Combobox value={selected} onChange={onChange}>
+        <div className="relative mt-1">
+          <div className="relative flex w-full cursor-default overflow-hidden rounded-lg bg-white text-left shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
+            <Combobox.Input
+              onChange={(event) => setQuery(event.target.value)}
+              className={className}
+            />
+            <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
+              <ChevronUpDownIcon
+                className="h-5 w-5 text-gray-400"
+                aria-hidden="true"
+              />
+            </Combobox.Button>
+          </div>
+          <Transition
+            as={Fragment}
+            leave="transition ease-in duration-100"
+            leaveFrom="opacity-100"
+            leaveTo="opacity-0"
+            afterLeave={() => setQuery("")}
+          >
+            <Combobox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
+              {filteredTags.length === 0 && query !== "" ? (
+                <Combobox.Option value={{ id: null, name: query }}>
+                  Create {query}
+                </Combobox.Option>
+              ) : (
+                filteredTags.map((tag) => (
+                  <Combobox.Option
+                    key={tag}
+                    className={({ active }) =>
+                      `relative cursor-default select-none py-2 pl-10 pr-4 ${
+                        active ? "bg-yellow-700 text-white" : "text-gray-900"
+                      }`
+                    }
+                    value={tag}
+                  >
+                    {({ selected, active }) => (
+                      <>
+                        <span
+                          className={`block truncate ${
+                            selected ? "font-medium" : "font-normal"
+                          }`}
+                        >
+                          {tag}
+                        </span>
+                        {selected ? (
+                          <span
+                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
+                              active ? "text-white" : "text-teal-600"
+                            }`}
+                          >
+                            <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                          </span>
+                        ) : null}
+                      </>
+                    )}
+                  </Combobox.Option>
+                ))
+              )}
+            </Combobox.Options>
+          </Transition>
+        </div>
+      </Combobox>
+    </div>
+  )
+}

--- a/src/components/ui/TagInput.tsx
+++ b/src/components/ui/TagInput.tsx
@@ -1,4 +1,5 @@
 import { Fragment, useCallback, useState } from "react"
+import { toast } from "react-hot-toast"
 import { shallow } from "zustand/shallow"
 
 import { Combobox, Transition } from "@headlessui/react"
@@ -18,9 +19,9 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
   const [selected, setSelected] = useState("")
   const [query, setQuery] = useState("")
 
-  const { tags, setValues } = useEditorState(
+  const { editorTags, setValues } = useEditorState(
     (state) => ({
-      tags: state.tags,
+      editorTags: state.tags === "" ? [] : state.tags?.split(","),
       setValues: state.setValues,
     }),
     shallow,
@@ -28,16 +29,22 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
 
   const onComboboxChange = useCallback(
     (value: string) => {
-      setValues({ tags: [...tags, value] })
+      if (editorTags.includes(value)) {
+        toast.error("Duplicate tags")
+        return
+      }
+      setValues({ tags: [...editorTags, value].join(",") })
     },
-    [setValues, tags],
+    [setValues, editorTags],
   )
 
   const onDel = useCallback(
     (value: string) => {
-      setValues({ tags: tags.filter((tag) => tag !== value) })
+      setValues({
+        tags: editorTags.filter((tag) => tag !== value).join(","),
+      })
     },
-    [setValues, tags],
+    [setValues, editorTags],
   )
 
   const filteredTags =
@@ -53,7 +60,7 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
   return (
     <div className="w-full">
       <div className="flex flex-wrap gap-2 mb-2">
-        {tags.map((tag) => (
+        {editorTags.map((tag) => (
           <div
             className="text-xs flex items-center font-bold leading-sm px-1 py-1 rounded-md"
             style={{

--- a/src/components/ui/TagInput.tsx
+++ b/src/components/ui/TagInput.tsx
@@ -3,13 +3,10 @@ import { toast } from "react-hot-toast"
 import { shallow } from "zustand/shallow"
 
 import { Combobox, Transition } from "@headlessui/react"
-import {
-  CheckIcon,
-  ChevronUpDownIcon,
-  XMarkIcon,
-} from "@heroicons/react/20/solid"
+import { ChevronUpDownIcon, XMarkIcon } from "@heroicons/react/20/solid"
 
 import { useEditorState } from "~/hooks/useEdtiorState"
+import { cn } from "~/lib/utils"
 
 interface Props extends HTMLInputElement {
   userTags: string[]
@@ -50,7 +47,7 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
   const filteredTags =
     query === ""
       ? userTags
-      : userTags.filter((tag) =>
+      : Array.from(new Set([query, ...userTags])).filter((tag) =>
           tag
             .toLowerCase()
             .replace(/\s+/g, "")
@@ -62,11 +59,7 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
       <div className="flex flex-wrap gap-2 mb-2">
         {editorTags.map((tag) => (
           <div
-            className="text-xs flex items-center font-bold leading-sm px-1 py-1 rounded-md"
-            style={{
-              background: "var(--theme-color)",
-              color: "rgba(var(--tw-colors-i-white), var(--tw-text-opacity))",
-            }}
+            className="text-xs flex items-center font-semibold p-1 rounded-md bg-accent text-white"
             key={tag}
           >
             <span>{tag}</span>
@@ -76,7 +69,7 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
       </div>
       <Combobox value={selected} onChange={onComboboxChange}>
         <div className="relative mt-1">
-          <div className="relative flex w-full cursor-default overflow-hidden rounded-lg bg-white text-left shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300 sm:text-sm">
+          <div className="relative flex w-full cursor-default overflow-hidden rounded-lg bg-white text-left sm:text-sm">
             <Combobox.Input
               onChange={(event) => setQuery(event.target.value)}
               autoComplete="off"
@@ -86,7 +79,7 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
             />
             <Combobox.Button className="absolute inset-y-0 right-0 flex items-center pr-2">
               <ChevronUpDownIcon
-                className="h-5 w-5 text-gray-400"
+                className="h-5 w-5 text-black"
                 aria-hidden="true"
               />
             </Combobox.Button>
@@ -98,45 +91,23 @@ export function TagInput({ userTags = [], className, id, name }: Props) {
             leaveTo="opacity-0"
             afterLeave={() => setQuery("")}
           >
-            <Combobox.Options className="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm">
-              {filteredTags.length === 0 && query !== "" ? (
-                <Combobox.Option value={query}>
-                  Create new tag: {query}
+            <Combobox.Options className="absolute max-h-60 w-full overflow-auto rounded-md bg-white p-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 sm:text-sm">
+              {filteredTags.map((tag) => (
+                <Combobox.Option
+                  key={tag}
+                  className={({ active }) =>
+                    cn(
+                      "relative cursor-default select-none py-2 px-4",
+                      active ? "bg-accent text-white" : "text-black",
+                    )
+                  }
+                  value={tag}
+                >
+                  <span className={cn("block truncate font-normal")}>
+                    {tag}
+                  </span>
                 </Combobox.Option>
-              ) : (
-                filteredTags.map((tag) => (
-                  <Combobox.Option
-                    key={tag}
-                    className={({ active }) =>
-                      `relative cursor-default select-none py-2 pl-10 pr-4 ${
-                        active ? "bg-yellow-700 text-white" : "text-gray-900"
-                      }`
-                    }
-                    value={tag}
-                  >
-                    {({ selected, active }) => (
-                      <>
-                        <span
-                          className={`block truncate ${
-                            selected ? "font-medium" : "font-normal"
-                          }`}
-                        >
-                          {tag}
-                        </span>
-                        {selected ? (
-                          <span
-                            className={`absolute inset-y-0 left-0 flex items-center pl-3 ${
-                              active ? "text-white" : "text-teal-600"
-                            }`}
-                          >
-                            <CheckIcon className="h-5 w-5" aria-hidden="true" />
-                          </span>
-                        ) : null}
-                      </>
-                    )}
-                  </Combobox.Option>
-                ))
-              )}
+              ))}
             </Combobox.Options>
           </Transition>
         </div>

--- a/src/hooks/useEdtiorState.ts
+++ b/src/hooks/useEdtiorState.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand"
+
+export interface Values {
+  title: string
+  publishedAt: string
+  published: boolean
+  excerpt: string
+  slug: string
+  tags: string[]
+  content: string
+}
+
+export const initialEditorState = {
+  title: "",
+  publishedAt: new Date().toISOString(),
+  published: false,
+  excerpt: "",
+  slug: "",
+  tags: [],
+  content: "",
+}
+
+export const useEditorState = create<
+  Values & {
+    setValues: (values: Partial<Values>) => void
+  }
+>((set) => ({
+  ...initialEditorState,
+  setValues: (values: any) => set(values),
+}))

--- a/src/hooks/useEdtiorState.ts
+++ b/src/hooks/useEdtiorState.ts
@@ -1,28 +1,19 @@
 import { create } from "zustand"
 
-export interface Values {
-  title: string
-  publishedAt: string
-  published: boolean
-  excerpt: string
-  slug: string
-  tags: string[]
-  content: string
-}
-
 export const initialEditorState = {
   title: "",
   publishedAt: new Date().toISOString(),
   published: false,
   excerpt: "",
   slug: "",
-  tags: [],
+  tags: "",
   content: "",
 }
+export type Values = typeof initialEditorState
 
 export const useEditorState = create<
-  Values & {
-    setValues: (values: Partial<Values>) => void
+  typeof initialEditorState & {
+    setValues: (values: Partial<typeof initialEditorState>) => void
   }
 >((set) => ({
   ...initialEditorState,

--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -519,6 +519,7 @@ export default function SubdomainEditor() {
       updateValue={updateValue}
       isPost={isPost}
       subdomain={subdomain}
+      userTags={userTags}
     />
   )
 

--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -835,8 +835,13 @@ const EditorExtraProperties: FC<{
           label={t("Tags") || ""}
           id="tags"
           isBlock
-          help={t("Separate multiple tags with English commas") + ` ","`}
-          renderInput={(props) => <TagInput {...props} userTags={userTags} />}
+          renderInput={(props) => (
+            <TagInput
+              {...props}
+              userTags={userTags}
+              onTagChange={(value: string) => updateValue("tags", value)}
+            />
+          )}
         />
       </div>
       <div>

--- a/src/pages/dashboard/[subdomain]/editor.tsx
+++ b/src/pages/dashboard/[subdomain]/editor.tsx
@@ -228,7 +228,7 @@ export default function SubdomainEditor() {
     if (check) {
       toast.error(check)
     } else {
-      const uniqueTags = Array.from(new Set(values.tags)).join(",")
+      const uniqueTags = Array.from(new Set(values.tags.split(","))).join(",")
       createOrUpdatePage.mutate({
         ...values,
         tags: uniqueTags,
@@ -294,9 +294,9 @@ export default function SubdomainEditor() {
       excerpt: page.data.metadata?.content?.summary || "",
       slug: page.data.metadata?.content?.slug || "",
       tags:
-        page.data.metadata?.content?.tags?.filter(
-          (tag) => tag !== "post" && tag !== "page",
-        ) || [],
+        page.data.metadata?.content?.tags
+          ?.filter((tag) => tag !== "post" && tag !== "page")
+          ?.join(", ") || "",
       content: page.data.metadata?.content?.content || "",
     })
     setDefaultSlug(


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7557208</samp>

This pull request refactors the editor page and the input component to improve the user experience of managing page tags. It introduces a new `TagInput` component that allows users to select or create tags from a combobox, and a new `renderInput` prop for the `Input` component that enables custom rendering of the input element. It also extracts the `useEditorState` hook to a separate file and changes the `tags` state type to an array of strings.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7557208</samp>

> _`TagInput` component_
> _Customizes editor state_
> _Autumn leaves of tags_

### WHY
A  tag autocomplete selector, related to #456


https://user-images.githubusercontent.com/4584859/236211797-08c5168e-7df7-438c-9903-e5203484b0d7.mov


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7557208</samp>

*  Add `TagInput` component to allow selecting or creating tags from a combobox ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-5ced9e79cd7baf463b0a4b4be0227056bdcb9db03d569e807dae572a0959c058R1-R139))
*  Move `useEditorState` hook to a separate file and change `tags` type to `string[]` ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-a1f60926e890a4958bdf386306659fd1e0af5085864835257dbf658354624a48R1-R30), [link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L74-L94), [link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L284-R299))
*  Import `useEditorState` hook and `TagInput` component in the editor page ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L36-R44))
*  Fetch pages by site with minimal data using `useGetPagesBySiteLite` query ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L54-R64))
*  Memoize array of unique tags from the pages data as `userTags` state ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R129-R152))
*  Pass `userTags` prop to `TagInput` component in the editor page and the `EditorSettings` component ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0R683), [link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L747-R762))
*  Render `TagInput` component as a custom input for the `Input` component using `renderInput` prop ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-842ea70ef7b4f5946fc6938a7a1eba15216a05a8bd9de0d2963aec6b8e0753c0L822-R838))
*  Import `useCallback`, `useMemo`, and `ReactElement` from `react` in the `Input` component ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-31c77d040d60718c619927412c606932a5cf03c81de6ec2ef354b7ab98e13a47L1-R2))
*  Add `renderInput` prop to the `InputProps` type to allow custom rendering of the input element ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-31c77d040d60718c619927412c606932a5cf03c81de6ec2ef354b7ab98e13a47R16))
*  Destructure `renderInput` prop from the `Input` component props ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-31c77d040d60718c619927412c606932a5cf03c81de6ec2ef354b7ab98e13a47R31))
*  Extract logic for choosing the input component into a `useMemo` hook and a `useCallback` function ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-31c77d040d60718c619927412c606932a5cf03c81de6ec2ef354b7ab98e13a47L37-R65))
*  Replace `Component` element by the `renderInputComponent` function call in the `Input` component ([link](https://github.com/Crossbell-Box/xLog/pull/485/files?diff=unified&w=0#diff-31c77d040d60718c619927412c606932a5cf03c81de6ec2ef354b7ab98e13a47L48-R75))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
