### PR TITLE
fix: support solidity syntax highlight

### DIFF
--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -6,6 +6,7 @@ import { toast } from "react-hot-toast"
 import { Element } from "react-scroll"
 import { refractor } from "refractor"
 import jsx from "refractor/lang/jsx"
+import solidity from "refractor/lang/solidity"
 import tsx from "refractor/lang/tsx"
 import rehypeAutolinkHeadings from "rehype-autolink-headings"
 import rehypeInferDescriptionMeta from "rehype-infer-description-meta"
@@ -73,6 +74,7 @@ export type Rendered = {
 refractor.alias("html", ["svelte", "vue"])
 refractor.register(tsx)
 refractor.register(jsx)
+refractor.register(solidity)
 
 const rehypePrism = rehypePrismGenerator(refractor)
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b57ab3a</samp>

This pull request enables syntax highlighting of `solidity` code blocks in markdown files. It modifies `src/markdown/index.ts` to use the `refractor` library and register the `solidity` language module.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b57ab3a</samp>

> _We're sailing on the web with markdown files_
> _We need to make them shine with colors bright_
> _So grab your `refractor` and your `solidity`_
> _And register the language on the count of three_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b57ab3a</samp>

* Enable syntax highlighting for solidity code blocks in markdown files by importing and registering the solidity language module from refractor ([link](https://github.com/Crossbell-Box/xLog/pull/489/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR9), [link](https://github.com/Crossbell-Box/xLog/pull/489/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR77))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
