### PR TITLE
fix: sitemap slug undefined

### DIFF
--- a/src/pages/_site/[site]/sitemap.xml.tsx
+++ b/src/pages/_site/[site]/sitemap.xml.tsx
@@ -34,7 +34,7 @@ export const getServerSideProps: GetServerSideProps = async (ctx) => {
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 ${pages.list?.map(
   (page: any) => `  <url>
-    <loc>${link}/${page.slug || page.id}</loc>
+    <loc>${link}/${page.metadata.content.slug}</loc>
     <lastmod>${dayjs(page.date_updated).format("YYYY-MM-DD")}</lastmod>
   </url>`,
 ).join(`


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fc6ac4</samp>

Fix broken links in sitemap.xml files for each site. Use the correct property to get the page slug from the page metadata.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3fc6ac4</samp>

> _Fix sitemap links_
> _`getServerSideProps` changed_
> _Winter bugs no more_

### WHY

[[Bug Report] Error in the sitemap.xml generation process](https://github.com/Crossbell-Box/xLog/issues/491)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3fc6ac4</samp>

* Fix a bug in generating sitemap.xml files for each site ([link](https://github.com/Crossbell-Box/xLog/pull/493/files?diff=unified&w=0#diff-38ed2503b29dba3639407a30e6599125398f3d2ef2cd27fb2b9bdd5f9b5699a4L37-R37))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
