### PR TITLE
fix: summary replace neutral subject

### DIFF
--- a/src/queries/page.server.ts
+++ b/src/queries/page.server.ts
@@ -173,9 +173,9 @@ const getOriginalSummary = async (cid: string, lang: string) => {
       let chain = chains.get(lang)
       if (!chain) {
         const prompt = new PromptTemplate({
-          template: `Summarize this in "${lang}" language:
-        "{text}"
-        CONCISE SUMMARY:`,
+          template: `Summarize this in "${lang}" language, if it's a neutral subject like "ta" or other, you should replace the subject with a neutral word equivalent to the target translation language:
+          "{text}"
+          CONCISE SUMMARY:`,
           inputVariables: ["text"],
         })
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at aad20b1</samp>

Refactor markdown removal and improve summarization prompt for neutral subjects. The file `src/pages/api/summary.ts` uses a new function `stripMarkdown` and modifies the prompt template to avoid biased summaries.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at aad20b1</samp>

> _`Refactor` the code, unleash the power_
> _`Utility` function, strip the markdown_
> _`Prompt` template, no more confusion_
> _`Neutral` subjects, face the summarization_

### WHY

If `ta` in zh, don't replace with he, should be they

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at aad20b1</samp>

*  Strip markdown syntax from input text using `removeMarkdown` function from `./src/utils/removeMarkdown.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/494/files?diff=unified&w=0#diff-0597cc186c7dfa1b87f2525f692d38b0cf0d6d70f0738706fce55e980b6b8ac2R5),[link](https://github.com/Crossbell-Box/xLog/pull/494/files?diff=unified&w=0#diff-0597cc186c7dfa1b87f2525f692d38b0cf0d6d70f0738706fce55e980b6b8ac2L11))
*  Modify prompt template for `getOriginalSummary` function to include clarification for neutral subjects ([link](https://github.com/Crossbell-Box/xLog/pull/494/files?diff=unified&w=0#diff-0597cc186c7dfa1b87f2525f692d38b0cf0d6d70f0738706fce55e980b6b8ac2L37-R37))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
