### PR TITLE
feat: use small summary image if no cover image

### DIFF
--- a/src/app/site/[site]/[slug]/page.tsx
+++ b/src/app/site/[site]/[slug]/page.tsx
@@ -38,6 +38,7 @@ export async function generateMetadata({
   const siteImages =
     site?.metadata?.content?.avatars || `${SITE_URL}/assets/logo.svg`
   const images = page?.metadata?.content?.cover || siteImages
+  const useLargeOGImage = !!page?.metadata?.content?.cover
   const twitterCreator =
     "@" +
     site?.metadata?.content?.connected_accounts
@@ -53,7 +54,7 @@ export async function generateMetadata({
       images,
     },
     twitter: {
-      card: "summary_large_image",
+      card: useLargeOGImage ? "summary_large_image" : "summary",
       title,
       description,
       images,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e82a34d</samp>

Added support for large social media previews using cover images. Enhanced `SEOHead` component with a new prop and updated meta tags. Modified `SiteLayout` component to pass cover images to `SEOHead`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e82a34d</samp>

> _Oh, we're the coders of the sea, and we work on the `SEOHead`_
> _We make the pages look so fine, when they're shared on social media_
> _Heave away, me jolly crew, heave away on the count of three_
> _We'll use the cover images, for the large previews that we need_

### WHY
<img width="605" alt="image" src="https://user-images.githubusercontent.com/41265413/236631315-6e1de0bd-dc43-4328-8c6f-ffa8f38aa511.png">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e82a34d</samp>

*  Add a new prop `largeOGImage` to the `SEOHead` component to control the size of the image for the Open Graph and Twitter cards meta tags ([link](https://github.com/Crossbell-Box/xLog/pull/495/files?diff=unified&w=0#diff-bcf31e100266e5bea6fb6a2219e7170f9e08dddc86e9b1ffcddcbe95609f504cL12-R13), [link](https://github.com/Crossbell-Box/xLog/pull/495/files?diff=unified&w=0#diff-bcf31e100266e5bea6fb6a2219e7170f9e08dddc86e9b1ffcddcbe95609f504cL22-R26))
*  Use the page data to determine whether to use a large or small image for the `SEOHead` component in the `SiteLayout` component ([link](https://github.com/Crossbell-Box/xLog/pull/495/files?diff=unified&w=0#diff-43426959eff98a692b60240b811291a96f1325bd39fc047cf10e89b32ce18513R77-R78), [link](https://github.com/Crossbell-Box/xLog/pull/495/files?diff=unified&w=0#diff-43426959eff98a692b60240b811291a96f1325bd39fc047cf10e89b32ce18513R107))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
