### PR TITLE
feat(i18n): fix site page Edit button translation

### DIFF
--- a/src/components/site/PostMeta.tsx
+++ b/src/components/site/PostMeta.tsx
@@ -88,7 +88,7 @@ export const PostMeta: React.FC<{
               page.metadata?.content?.tags?.includes("post") ? "post" : "page"
             }`}
           >
-            <i className="icon-[mingcute--edit-line] mx-1" /> Edit
+            <i className="icon-[mingcute--edit-line] mx-1" /> {t("Edit")}
           </UniLink>
         )}
       </div>


### PR DESCRIPTION
### WHAT
change "Edit" text to i18n translation.
### WHY
<!-- author to complete -->
I have noticed that the edit button has not been used to correct the Chinese translation.
### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a419de4</samp>

*  Localize the "Edit" text in the post meta component ([link](https://github.com/Crossbell-Box/xLog/pull/501/files?diff=unified&w=0#diff-22f041acb0e3c878e0fc6ac9c0a59b9321bc199ab31c2df6cd3d14195141fe10L91-R91))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
