### PR TITLE
feat: support button for uploading all images to ipfs

### DIFF
--- a/src/editor/Cloud.tsx
+++ b/src/editor/Cloud.tsx
@@ -26,9 +26,11 @@ const uploadResources = async (text: string) => {
             newMarkdown: `![${altText}](${key})`,
           }
         } catch (error) {
-          toast.error(`Failed upload ${altText || url}, ${error.message}`, {
-            id: toastId,
-          })
+          if (error instanceof Error) {
+            toast.error(`Failed upload ${altText || url}, ${error.message}`, {
+              id: toastId,
+            })
+          }
           console.error(error)
           return undefined
         }

--- a/src/editor/Cloud.tsx
+++ b/src/editor/Cloud.tsx
@@ -1,6 +1,6 @@
 import toast from "react-hot-toast"
 
-import { toGateway } from "~/lib/ipfs-parser"
+import { IPFS_PREFIX } from "~/lib/ipfs-parser"
 import { UploadFile } from "~/lib/upload-file"
 
 import { ICommand } from "."
@@ -11,13 +11,16 @@ const uploadResources = async (text: string) => {
   if (match) {
     const altText = match[1]
     const url = match[2]
-    console.log({ url })
+
+    if (url.startsWith(IPFS_PREFIX)) {
+      return text
+    }
+
     const blob = await fetch(url, {
       mode: "no-cors",
     }).then((response) => response.blob())
     const key = (await UploadFile(blob)).key
-    const newUrl = toGateway(key)
-    return `![${altText}](${newUrl})`
+    return `![${altText}](${key})`
   } else {
     return text
   }

--- a/src/editor/Cloud.tsx
+++ b/src/editor/Cloud.tsx
@@ -1,0 +1,49 @@
+import toast from "react-hot-toast"
+
+import { toGateway } from "~/lib/ipfs-parser"
+import { UploadFile } from "~/lib/upload-file"
+
+import { ICommand } from "."
+
+const uploadResources = async (text: string) => {
+  const markdownImageRegex = /!\[(.*)\]\((.+)\)/
+  const match = text.match(markdownImageRegex)
+  if (match) {
+    const altText = match[1]
+    const url = match[2]
+    console.log({ url })
+    const blob = await fetch(url, {
+      mode: "no-cors",
+    }).then((response) => response.blob())
+    const key = (await UploadFile(blob)).key
+    const newUrl = toGateway(key)
+    return `![${altText}](${newUrl})`
+  } else {
+    return text
+  }
+}
+
+export const Cloud: ICommand = {
+  name: "cloud",
+  label: "Upload All Images to IPFS",
+  icon: "icon-[mingcute--upload-3-line]",
+  execute: async ({ view }) => {
+    const toastId = toast.loading("Uploading...")
+    const docJson = view.state.doc.toJSON()
+    const newDocJson = await Promise.all(
+      docJson.map((line: string) => uploadResources(line)),
+    )
+    view.dispatch({
+      changes: [
+        {
+          from: 0,
+          to: view.state.doc.toString().length,
+          insert: newDocJson.join("\n"),
+        },
+      ],
+    })
+    toast.success("Uploaded!", {
+      id: toastId,
+    })
+  },
+}

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -4,6 +4,7 @@ import { EditorSelection } from "@codemirror/state"
 import { EditorView } from "@codemirror/view"
 
 import { Bold } from "./Bold"
+import { Cloud } from "./Cloud"
 import { Code } from "./Code"
 import { CodeBlock } from "./CodeBlock"
 import { Emoji } from "./Emoji"
@@ -142,5 +143,6 @@ export const toolbars: ICommand[] = [
   Image,
   Mention,
   Emoji,
+  Cloud,
   Help,
 ]

--- a/src/lib/ipfs-parser.ts
+++ b/src/lib/ipfs-parser.ts
@@ -1,6 +1,6 @@
 import { IPFS_GATEWAY } from "~/lib/env"
 
-const IPFS_PREFIX = "ipfs://"
+export const IPFS_PREFIX = "ipfs://"
 
 export type ToGatewayConfig = {
   needRequestAtServerSide?: boolean


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7dcb6b</samp>

This pull request adds a `Cloud` command to the editor that uploads images in the markdown document to IPFS and updates their URLs. This enhances the cloud storage functionality and the resilience of the images.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b7dcb6b</samp>

> _Rise up and resist the tyranny of the web_
> _`Cloud` command will set your images free_
> _Upload them to IPFS with a single click_
> _No more broken links or censorship_

### WHY
#452 

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b7dcb6b</samp>

*  Add a new `Cloud` command to the editor that uploads images to IPFS and replaces their URLs ([link](https://github.com/Crossbell-Box/xLog/pull/504/files?diff=unified&w=0#diff-02d328f0c4ad552705f404d597ed4c7c9b7b6c377a7554c9db2dcf0c4d7b74acR1-R49), [link](https://github.com/Crossbell-Box/xLog/pull/504/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR7), [link](https://github.com/Crossbell-Box/xLog/pull/504/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR146))
  * The command uses a helper function `uploadResources` that fetchs and uploads image blobs using `UploadFile` from `~/lib/upload-file` ([link](https://github.com/Crossbell-Box/xLog/pull/504/files?diff=unified&w=0#diff-02d328f0c4ad552705f404d597ed4c7c9b7b6c377a7554c9db2dcf0c4d7b74acR1-R49))
  * The command shows a toast notification to indicate the upload progress and result ([link](https://github.com/Crossbell-Box/xLog/pull/504/files?diff=unified&w=0#diff-02d328f0c4ad552705f404d597ed4c7c9b7b6c377a7554c9db2dcf0c4d7b74acR1-R49))
  * The command is imported from the `./Cloud` module to the main editor module ([link](https://github.com/Crossbell-Box/xLog/pull/504/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR7))
  * The command is added to the list of commands passed to the `MenuBar` component, which renders the toolbar ([link](https://github.com/Crossbell-Box/xLog/pull/504/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR146))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
