### PR TITLE
feat: Support Custom domain for feed

### DIFF
--- a/src/lib/json-feed.ts
+++ b/src/lib/json-feed.ts
@@ -27,6 +27,7 @@ export const getJsonFeed = async (domainOrSubdomain: string, path: string) => {
   const hasAudio = pages.list?.find((page) => page.metadata?.content?.audio)
 
   const link = getSiteLink({
+    domain: site?.metadata?.content?.custom_domain,
     subdomain: site?.handle || "",
   })
   return {


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3a91cf3</samp>

Add `domain` property to JSON feed object. This allows users to set custom domains for their sites and have them reflected in the feed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3a91cf3</samp>

> _`getJsonFeed` adds_
> _`domain` from site metadata_
> _A custom spring bloom_

### WHY
<!-- author to complete -->
Support Custom domain for feed

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3a91cf3</samp>

*  Add `domain` property to JSON feed object ([link](https://github.com/Crossbell-Box/xLog/pull/506/files?diff=unified&w=0#diff-b24fdbd9e87c973826963aecee6716ac84b83fb7fc0574cbaa1615a3fb34e0cfR30))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
