### PR TITLE
feat: support self-hosted umami

### DIFF
--- a/public/locales/ja/dashboard.json
+++ b/public/locales/ja/dashboard.json
@@ -87,6 +87,7 @@
   "Description": "説明",
   "Integrate Google Analytics": "Google Analytics と紐付けします。Measurement ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
   "Integrate Umami Cloud Analytics": "Umami Cloud Analytics と紐付けします。Website ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
+  "Integrate Umami Cloud Analytics (set url)": "空欄にして、<2>公式サービス</2>を使用してください。",
   "Save": "保存",
   "Tips": "ヒント",
   "social tips": {

--- a/public/locales/zh-TW/dashboard.json
+++ b/public/locales/zh-TW/dashboard.json
@@ -92,6 +92,7 @@
     "Description": "自我介紹",
     "Integrate Google Analytics": "將 Google Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Measurement ID。",
     "Integrate Umami Cloud Analytics": "將 Umami Cloud Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Website ID。",
+    "Integrate Umami Cloud Analytics (set url)": "留空以使用<2>官方服務</2>。",
     "Save": "儲存",
     "Tips": "提示",
     "social tips": {

--- a/public/locales/zh/dashboard.json
+++ b/public/locales/zh/dashboard.json
@@ -93,6 +93,7 @@
   "Description": "描述",
   "Integrate Google Analytics": "将 Google Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Measurement ID。",
   "Integrate Umami Cloud Analytics": "将 Umami Cloud Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Website ID。",
+  "Integrate Umami Cloud Analytics (set url)": "留空以使用<2>官方服务</2>。",
   "Save": "保存",
   "Tips": "提示",
   "social tips": {

--- a/src/app/dashboard/[subdomain]/settings/general/page.tsx
+++ b/src/app/dashboard/[subdomain]/settings/general/page.tsx
@@ -30,6 +30,7 @@ export default function SiteSettingsGeneralPage() {
       description: "",
       ga: "",
       ua: "",
+      uh: "",
     } as {
       icon: string
       banner?: {
@@ -40,6 +41,7 @@ export default function SiteSettingsGeneralPage() {
       description: string
       ga: string
       ua: string
+      uh: string
     },
   })
 
@@ -52,6 +54,7 @@ export default function SiteSettingsGeneralPage() {
       description: values.description,
       ga: values.ga,
       ua: values.ua,
+      uh: values.uh,
     })
   })
 
@@ -94,6 +97,8 @@ export default function SiteSettingsGeneralPage() {
         form.setValue("ga", site.data.metadata?.content?.ga || "")
       !form.getValues("ua") &&
         form.setValue("ua", site.data.metadata?.content?.ua || "")
+      !form.getValues("uh") &&
+        form.setValue("uh", site.data.metadata?.content?.uh || "")
     }
   }, [site.data, form])
 
@@ -206,9 +211,32 @@ export default function SiteSettingsGeneralPage() {
         </div>
         <div className="mt-5">
           <Input
-            id="ua"
-            {...form.register("ua")}
+            id="uh"
+            {...form.register("uh")}
+            prefix="https://"
+            addon="/script.js"
+            placeholder="analytics.umami.is"
             label="Umami Cloud Analytics"
+            help={
+              <p>
+                <Trans
+                  i18nKey="Integrate Umami Cloud Analytics (set url)"
+                  ns="dashboard"
+                >
+                  Leave blank to use{" "}
+                  <UniLink className="underline" href="https://umami.is/">
+                    the official service
+                  </UniLink>
+                  .
+                </Trans>
+              </p>
+            }
+          />
+          <Input
+            id="ua"
+            className="mt-2"
+            {...form.register("ua")}
+            placeholder="xxxxxxxx-xxxx-..."
             help={
               <p>
                 <Trans

--- a/src/app/dashboard/[subdomain]/settings/general/page.tsx
+++ b/src/app/dashboard/[subdomain]/settings/general/page.tsx
@@ -214,7 +214,6 @@ export default function SiteSettingsGeneralPage() {
             id="uh"
             {...form.register("uh")}
             prefix="https://"
-            addon="/script.js"
             placeholder="analytics.umami.is"
             label="Umami Cloud Analytics"
             help={

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -113,9 +113,12 @@ export default async function SiteFooter({
             id="umami-analytics"
             strategy="afterInteractive"
             async
-            src={`https://${
-              site.metadata?.content?.uh || "analytics.umami.is"
-            }/script.js`}
+            src={`https://analytics.umami.is`}
+            data-host-url={
+              site.metadata?.content?.uh
+                ? `https://${site.metadata?.content?.uh}`
+                : null
+            }
             data-website-id={`${site.metadata?.content?.ua}`}
           ></Script>
         </div>

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -113,7 +113,9 @@ export default async function SiteFooter({
             id="umami-analytics"
             strategy="afterInteractive"
             async
-            src="https://analytics.umami.is/script.js"
+            src={`https://${
+              site.metadata?.content?.uh || "analytics.umami.is"
+            }/script.js`}
             data-website-id={`${site.metadata?.content?.ua}`}
           ></Script>
         </div>

--- a/src/lib/expand-unit.ts
+++ b/src/lib/expand-unit.ts
@@ -110,6 +110,10 @@ export const expandCrossbellCharacter = (site: CharacterEntity) => {
     (expandedCharacter.metadata?.content?.attributes?.find(
       (a: any) => a.trait_type === "xlog_ua",
     )?.value as string) || ""
+  expandedCharacter.metadata.content.uh =
+    (expandedCharacter.metadata?.content?.attributes?.find(
+      (a: any) => a.trait_type === "xlog_uh",
+    )?.value as string) || ""
   expandedCharacter.metadata.content.custom_domain =
     (expandedCharacter.metadata?.content?.attributes?.find(
       (a: any) => a.trait_type === "xlog_custom_domain",

--- a/src/lib/i18n/locales/ja/dashboard.json
+++ b/src/lib/i18n/locales/ja/dashboard.json
@@ -87,6 +87,7 @@
   "Description": "説明",
   "Integrate Google Analytics": "Google Analytics と紐付けします。Measurement ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
   "Integrate Umami Cloud Analytics": "Umami Cloud Analytics と紐付けします。Website ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
+  "Integrate Umami Cloud Analytics (set url)": "空欄にして、<2>公式サービス</2>を使用してください。",
   "Save": "保存",
   "Tips": "ヒント",
   "social tips": {

--- a/src/lib/i18n/locales/zh-TW/dashboard.json
+++ b/src/lib/i18n/locales/zh-TW/dashboard.json
@@ -92,6 +92,7 @@
     "Description": "自我介紹",
     "Integrate Google Analytics": "將 Google Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Measurement ID。",
     "Integrate Umami Cloud Analytics": "將 Umami Cloud Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Website ID。",
+    "Integrate Umami Cloud Analytics (set url)": "留空以使用<2>官方服務</2>。",
     "Save": "儲存",
     "Tips": "提示",
     "social tips": {

--- a/src/lib/i18n/locales/zh/dashboard.json
+++ b/src/lib/i18n/locales/zh/dashboard.json
@@ -93,6 +93,7 @@
   "Description": "描述",
   "Integrate Google Analytics": "将 Google Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Measurement ID。",
   "Integrate Umami Cloud Analytics": "将 Umami Cloud Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Website ID。",
+  "Integrate Umami Cloud Analytics (set url)": "留空以使用<2>官方服务</2>。",
   "Save": "保存",
   "Tips": "提示",
   "social tips": {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,7 @@ export type ExpandedCharacter = CharacterEntity & {
       css?: string
       ga?: string
       ua?: string
+      uh?: string
       custom_domain?: string
     }
   }

--- a/src/models/site.model.ts
+++ b/src/models/site.model.ts
@@ -107,6 +107,7 @@ export async function updateSite(
     css?: string
     ga?: string
     ua?: string
+    uh?: string
     custom_domain?: string
     banner?: {
       address: string
@@ -143,6 +144,7 @@ export async function updateSite(
         payload.css !== undefined ||
         payload.ga !== undefined ||
         payload.ua !== undefined ||
+        payload.uh !== undefined ||
         payload.custom_domain !== undefined) && {
         attributes: [
           ...(payload.navigation !== undefined
@@ -174,6 +176,14 @@ export async function updateSite(
                 {
                   trait_type: "xlog_ua",
                   value: payload.ua,
+                },
+              ]
+            : []),
+          ...(payload.uh !== undefined
+            ? [
+                {
+                  trait_type: "xlog_uh",
+                  value: payload.uh,
                 },
               ]
             : []),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0e3bbd9</samp>

This pull request adds a new feature that allows users to enter a custom URL for the Umami Cloud Analytics script for their sites and characters. It modifies the `GeneralSettingsPage` component, the `updateSite` function, the `SiteFooter` component, the `expandCrossbellCharacter` function, and the `ExpandedCharacter` type to support the feature. It also adds and updates the translation keys and values for the dashboard in the `public/locales` and `src/lib/i18n/locales` folders.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0e3bbd9</samp>

> _`Umami Cloud Analytics` in your site_
> _Customize the URL or leave it blank_
> _`ExpandedCharacter` with a new trait_
> _`updateSite` function seals your fate_

### WHY

Support the self-hosted version of umami

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0e3bbd9</samp>

*  Add a new state variable, type declaration, and input component for the custom URL for the Umami Cloud Analytics script in the `GeneralSettingsPage` component ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R33), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R44), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245L205-R235))
*  Send the user input for the custom URL to the backend in the `updateSite` function call in the `GeneralSettingsPage` component ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R57))
*  Populate the input field with the existing value of the custom URL from the `site` query in the `GeneralSettingsPage` component ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R100-R101))
*  Load the custom URL or the default URL for the Umami Cloud Analytics script in the `SiteFooter` component ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-765d257cdb9e99b90862bdf509d92d60910659262e97a25f78e2c48a44847bcfL110-R112))
*  Store the custom URL for the Umami Cloud Analytics script in the `expandedCharacter` object in the `expandCrossbellCharacter` function ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-0802612f2ebfab23d2656fc2189271c4fef6451452a2bd7dacc8d8bcfe11e2e8R113-R116))
*  Update the custom URL for the Umami Cloud Analytics script in the database in the `updateSite` function in the `src/models/site.model.ts` file ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R110), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R147), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R182-R189))
*  Add a new optional property for the custom URL to the `ExpandedCharacter` type in the `src/lib/types.ts` file ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R105))
*  Add new translation keys and values for the help text for the input field in the Japanese, Traditional Chinese, and Simplified Chinese locales in the `public/locales` and `src/lib/i18n/locales` folders ([link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-672f3a5746f1d60bb9fa456dd4ddfe70a24c397e436e73001a2114f360b5c635R90), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-20d6f7fc6b8cf3a7cd045ffc933ca8457bba669db9007f4c24a8e3ef0d748bb9R95), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-b96cdea1e3b6db8de6ba9473897c4c805f83a25e6b7fef25f339cb2cd95722cbR96), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-35732bfc6b9d2c778d4e207e3db92728acd62080a69343c11e35e7a49dc4b532R90), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-7e65bab74206cf373f8f3034c1de7acdd15ed2fc4b912e47c67a951dc7db01e7R95), [link](https://github.com/Crossbell-Box/xLog/pull/520/files?diff=unified&w=0#diff-3b3413294ac416902eb47e3aa9ac357b0ebb21b46f7ea157940981b0d2f3c977R96))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.

xLog bryan

discord Singee#2858

