### PR TITLE
feat: add Microsoft Clarity Analysis

### DIFF
--- a/public/locales/ja/dashboard.json
+++ b/public/locales/ja/dashboard.json
@@ -87,6 +87,7 @@
   "Description": "説明",
   "Integrate Google Analytics": "Google Analytics と紐付けします。Measurement ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
   "Integrate Umami Cloud Analytics": "Umami Cloud Analytics と紐付けします。Website ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
+  "Integrate Microsoft Clarity Analytics": "Microsoft Clarity Analytics と紐付けします。Website ID の検索方法については、<2>こちらの文章</2>をご覧ください。",
   "Save": "保存",
   "Tips": "ヒント",
   "social tips": {

--- a/public/locales/zh-TW/dashboard.json
+++ b/public/locales/zh-TW/dashboard.json
@@ -92,6 +92,7 @@
     "Description": "自我介紹",
     "Integrate Google Analytics": "將 Google Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Measurement ID。",
     "Integrate Umami Cloud Analytics": "將 Umami Cloud Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Website ID。",
+    "Integrate Microsoft Clarity Analytics": "將 Microsoft Clarity Analytics 整合至你的網站中。請按照<2>這裡</2>的說明查找你的 Website ID。",
     "Save": "儲存",
     "Tips": "提示",
     "social tips": {

--- a/public/locales/zh/dashboard.json
+++ b/public/locales/zh/dashboard.json
@@ -93,6 +93,7 @@
   "Description": "描述",
   "Integrate Google Analytics": "将 Google Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Measurement ID。",
   "Integrate Umami Cloud Analytics": "将 Umami Cloud Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Website ID。",
+  "Integrate Microsoft Clarity Analytics": "将 Microsoft Clarity Analytics 集成到你的站点中。你可以按照<2>这里</2>的说明查找你的 Website ID。",
   "Save": "保存",
   "Tips": "提示",
   "social tips": {

--- a/src/app/dashboard/[subdomain]/settings/general/page.tsx
+++ b/src/app/dashboard/[subdomain]/settings/general/page.tsx
@@ -40,6 +40,7 @@ export default function SiteSettingsGeneralPage() {
       description: string
       ga: string
       ua: string
+      ma: string
     },
   })
 
@@ -52,6 +53,7 @@ export default function SiteSettingsGeneralPage() {
       description: values.description,
       ga: values.ga,
       ua: values.ua,
+      ma: values.ma,
     })
   })
 
@@ -94,6 +96,8 @@ export default function SiteSettingsGeneralPage() {
         form.setValue("ga", site.data.metadata?.content?.ga || "")
       !form.getValues("ua") &&
         form.setValue("ua", site.data.metadata?.content?.ua || "")
+      !form.getValues("ma") &&
+        form.setValue("ma", site.data.metadata?.content?.ua || "")
     }
   }, [site.data, form])
 
@@ -221,6 +225,32 @@ export default function SiteSettingsGeneralPage() {
                   <UniLink
                     className="underline"
                     href="https://umami.is/docs/collect-data"
+                  >
+                    here
+                  </UniLink>{" "}
+                  to find your Website ID.
+                </Trans>
+              </p>
+            }
+          />
+        </div>
+        <div className="mt-5">
+          <Input
+            id="ma"
+            {...form.register("ma")}
+            label="Microsoft Clarity Analytics"
+            help={
+              <p>
+                <Trans
+                  i18n={i18n}
+                  i18nKey="Integrate Microsoft Clarity Analytics"
+                  ns="dashboard"
+                >
+                  Integrate Microsoft Clarity Analytics into your site. You can follow
+                  the instructions{" "}
+                  <UniLink
+                    className="underline"
+                    href="https://learn.microsoft.com/en-us/clarity/setup-and-installation/clarity-setup"
                   >
                     here
                   </UniLink>{" "}

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -118,6 +118,19 @@ export default async function SiteFooter({
           ></Script>
         </div>
       )}
+      {site?.metadata?.content?.ma && (
+      <div className="xlog-microsoft-analytics">
+        <Script id="microsoft-analytics" strategy="afterInteractive">
+          {`
+          (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+          })(window, document, "clarity", "script", "${site.metadata?.content?.ma}");
+          `}
+    </Script>
+  </div>
+)}
     </>
   )
 }

--- a/src/lib/expand-unit.ts
+++ b/src/lib/expand-unit.ts
@@ -110,6 +110,10 @@ export const expandCrossbellCharacter = (site: CharacterEntity) => {
     (expandedCharacter.metadata?.content?.attributes?.find(
       (a: any) => a.trait_type === "xlog_ua",
     )?.value as string) || ""
+  expandedCharacter.metadata.content.ma =
+    (expandedCharacter.metadata?.content?.attributes?.find(
+      (a: any) => a.trait_type === "xlog_ma",
+    )?.value as string) || ""
   expandedCharacter.metadata.content.custom_domain =
     (expandedCharacter.metadata?.content?.attributes?.find(
       (a: any) => a.trait_type === "xlog_custom_domain",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,7 @@ export type ExpandedCharacter = CharacterEntity & {
       css?: string
       ga?: string
       ua?: string
+      ma?: string
       custom_domain?: string
     }
   }

--- a/src/models/site.model.ts
+++ b/src/models/site.model.ts
@@ -107,6 +107,7 @@ export async function updateSite(
     css?: string
     ga?: string
     ua?: string
+    ma?: string
     custom_domain?: string
     banner?: {
       address: string
@@ -143,6 +144,7 @@ export async function updateSite(
         payload.css !== undefined ||
         payload.ga !== undefined ||
         payload.ua !== undefined ||
+        payload.ma !== undefined ||
         payload.custom_domain !== undefined) && {
         attributes: [
           ...(payload.navigation !== undefined
@@ -174,6 +176,14 @@ export async function updateSite(
                 {
                   trait_type: "xlog_ua",
                   value: payload.ua,
+                },
+              ]
+            : []),
+          ...(payload.ma !== undefined
+            ? [
+                {
+                  trait_type: "xlog_ma",
+                  value: payload.ma,
                 },
               ]
             : []),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80f82b3</samp>

This pull request adds a new feature to the dashboard that allows users to integrate `Microsoft Clarity Analytics` with their sites. It adds and updates translations, validation, and rendering logic for the new option in various files. It also fixes some JSON syntax errors in the locale files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 80f82b3</samp>

> _Sing, O Muse, of the skillful code reviewers_
> _Who scrutinized the changes of the pull request_
> _And offered wise and helpful feedback to the authors_
> _Who added Clarity Analytics to the site settings._

### WHY
<!-- author to complete -->
feat: add Microsoft Clarity Analysis

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 80f82b3</samp>

*  Add a new property `ma` to store the Website ID for Clarity in the site settings and metadata ([link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R43), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-0802612f2ebfab23d2656fc2189271c4fef6451452a2bd7dacc8d8bcfe11e2e8R113-R116), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R105), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R110))
*  Update the site settings form in the general page of the dashboard to include an input component for the Clarity Website ID, with translation and help text ([link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R56), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R99-R100), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-fcdb6dd297ab430ed34aab79585386ccb425672b82314187806ee2af0d9b5245R238-R263))
*  Update the site metadata content in the database with the new `ma` value when the site settings form is submitted, if it has been changed ([link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R147), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-8db5e50556c7105744e774aa64e610078c43b9a84d4e2d39bc7fcdaca85d6760R182-R189))
*  Load the Clarity script into the site footer if the site metadata content has a valid `ma` value, using the `next/script` component ([link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-765d257cdb9e99b90862bdf509d92d60910659262e97a25f78e2c48a44847bcfR121-R133))
*  Add translations for the option to integrate Clarity into the site for the Japanese, Traditional Chinese, and Simplified Chinese locales of the dashboard, in the `dashboard.json` files ([link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-672f3a5746f1d60bb9fa456dd4ddfe70a24c397e436e73001a2114f360b5c635R90), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-20d6f7fc6b8cf3a7cd045ffc933ca8457bba669db9007f4c24a8e3ef0d748bb9R95), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-b96cdea1e3b6db8de6ba9473897c4c805f83a25e6b7fef25f339cb2cd95722cbR96))
*  Fix missing commas at the end of the JSON objects for the Japanese, Traditional Chinese, and Simplified Chinese locales of the dashboard, in the `dashboard.json` files ([link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-672f3a5746f1d60bb9fa456dd4ddfe70a24c397e436e73001a2114f360b5c635L124-R125), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-20d6f7fc6b8cf3a7cd045ffc933ca8457bba669db9007f4c24a8e3ef0d748bb9L198-R199), [link](https://github.com/Crossbell-Box/xLog/pull/523/files?diff=unified&w=0#diff-b96cdea1e3b6db8de6ba9473897c4c805f83a25e6b7fef25f339cb2cd95722cbL204-R205))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.

c-5934   cjh0613 
