### PR TITLE
fix(Menu): fix invisible dropdown on mobile screens

### DIFF
--- a/src/components/ui/Menu.tsx
+++ b/src/components/ui/Menu.tsx
@@ -1,10 +1,17 @@
 import Link from "next/link"
-import { Fragment } from "react"
+import React, { Fragment } from "react"
 
+import { autoUpdate, shift, useFloating } from "@floating-ui/react"
 import { Menu as HeadlessUiMenu } from "@headlessui/react"
 
 import { cn } from "~/lib/utils"
 
+/**
+ * A dropdown menu that is opened by clicking on the target element.
+ *
+ * Use Headless UI for **accessible** interactions,
+ * and Floating UI for positioning.
+ */
 export function Menu({
   target,
   dropdown,
@@ -14,17 +21,26 @@ export function Menu({
   dropdown: React.ReactNode
   placement?: "bottom-start" | "bottom-end"
 }>) {
+  const { refs, floatingStyles } = useFloating({
+    placement,
+    middleware: [
+      // Prevent overflowing viewport
+      shift({ padding: 20 }),
+    ],
+    whileElementsMounted: autoUpdate,
+  })
+
   return (
     <HeadlessUiMenu>
-      <HeadlessUiMenu.Button as={Fragment}>{target}</HeadlessUiMenu.Button>
+      <HeadlessUiMenu.Button as={Fragment}>
+        {React.cloneElement(target, { ref: refs.setReference })}
+      </HeadlessUiMenu.Button>
       <HeadlessUiMenu.Items
+        ref={refs.setFloating}
         className={cn(
-          "fixed z-10 mt-1 w-full outline-none text-gray-600 bg-white rounded-lg ring-1 ring-border shadow-md py-2 md:absolute md:w-max",
-          {
-            "bottom-start": "top-[100%] left-0",
-            "bottom-end": "top-[100%] right-0",
-          }[placement],
+          "absolute z-10 mt-1 w-max outline-none text-gray-600 bg-white rounded-lg ring-1 ring-border shadow-md py-2",
         )}
+        style={floatingStyles}
       >
         {dropdown}
       </HeadlessUiMenu.Items>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 447818f</samp>

This pull request improves the `Menu` component by using a library for better layout and adding documentation comments. It affects the file `src/components/ui/Menu.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 447818f</samp>

> _`Menu` of doom, unleash the power of Floating UI_
> _Position your items with precision and style_
> _Document your code with JSDoc, enlighten the masses_
> _`Menu` of doom, you are the master of the interface_

https://github.com/Crossbell-Box/xLog/assets/8225666/e8854f44-a80d-4993-806c-739fe334973f

### WHY

The menu was styled `position:fixed;top:100`, which may cause the element to be positioned beyond the bottom edge of viewport.

Leverage Floating UI for more flexible and precise control of overlay positioning.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 447818f</samp>

* Import React and document the `Menu` component with JSDoc ([link](https://github.com/Crossbell-Box/xLog/pull/524/files?diff=unified&w=0#diff-83f41a1bc395f5576bafba57dfb869b03577e0e558235312013169c29bb6a1bbL2-R14))
* Use the `useFloating` hook from Floating UI to position the menu items dynamically and adjust to viewport boundaries ([link](https://github.com/Crossbell-Box/xLog/pull/524/files?diff=unified&w=0#diff-83f41a1bc395f5576bafba57dfb869b03577e0e558235312013169c29bb6a1bbL17-R43))
* Pass the `placement` prop and the `middleware` array to the hook to customize the positioning logic ([link](https://github.com/Crossbell-Box/xLog/pull/524/files?diff=unified&w=0#diff-83f41a1bc395f5576bafba57dfb869b03577e0e558235312013169c29bb6a1bbL17-R43))
* Apply the refs and styles returned by the hook to the target and the menu items elements ([link](https://github.com/Crossbell-Box/xLog/pull/524/files?diff=unified&w=0#diff-83f41a1bc395f5576bafba57dfb869b03577e0e558235312013169c29bb6a1bbL17-R43))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
