### PR TITLE
feat: add some semantic class

### DIFF
--- a/src/app/site/[site]/layout.tsx
+++ b/src/app/site/[site]/layout.tsx
@@ -159,16 +159,16 @@ export default async function SiteLayout({
       >
         <Style content={site?.metadata?.content?.css} />
         {site && <SiteHeader handle={params.site} />}
-        <div
+        <main
           className={cn(
             `xlog-post-id-${page?.characterId}-${page?.noteId}`,
             "xlog-deprecated-class xlog-post-area max-w-screen-md mx-auto px-5 pt-12 relative",
           )}
         >
           {children}
-        </div>
+        </main>
         {site && (
-          <div className="max-w-screen-md mx-auto pt-12 pb-10">
+          <div className="xlog-blockchain-info max-w-screen-md mx-auto pt-12 pb-10">
             <BlockchainInfo site={site} page={page || undefined} />
           </div>
         )}

--- a/src/components/common/DarkModeSwitch.tsx
+++ b/src/components/common/DarkModeSwitch.tsx
@@ -3,6 +3,7 @@
 import { Switch } from "@headlessui/react"
 
 import { useDarkModeSwitch, useIsDark } from "~/hooks/useDarkMode"
+import { cn } from "~/lib/utils"
 
 export const DarkModeSwitch = () => {
   const toggle = useDarkModeSwitch()
@@ -11,9 +12,10 @@ export const DarkModeSwitch = () => {
     <Switch
       checked={isDark || false}
       onChange={toggle}
-      className={`${
-        isDark ? "bg-accent" : "bg-gray-200"
-      } relative inline-flex h-6 w-11 items-center rounded-full text-base dark:text-always-gray-200 text-always-gray-700 align-middle`}
+      className={cn(
+        `${isDark ? "bg-accent" : "bg-gray-200"}`,
+        ` relative inline-flex h-6 w-11 items-center rounded-full text-base dark:text-always-gray-200 text-always-gray-700 align-middle`,
+      )}
     >
       <span className="sr-only">Switch Dark Mode</span>
       <span

--- a/src/components/site/SiteFooter.tsx
+++ b/src/components/site/SiteFooter.tsx
@@ -50,7 +50,7 @@ export default async function SiteFooter({
             />
           </div>
           {site?.metadata?.content?.connected_accounts && (
-            <div className="sm:-mr-5 sm:block inline-block align-middle mr-4">
+            <div className="xlog-social-platforms sm:-mr-5 sm:block inline-block align-middle mr-4">
               {site?.metadata?.content?.connected_accounts.map(
                 (
                   account:

--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -333,7 +333,7 @@ export const SiteHeader: React.FC<{
               return <HeaderLink link={link} key={`${link.label}${i}`} />
             })}
           </div>
-          <div className="pl-1">
+          <div className="xlog-connect-account pl-1">
             <ConnectButton variant="text" mobileSimplification={true} />
           </div>
         </div>


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f8681e</samp>

This pull request improves the layout and accessibility of the site pages and the code quality and style of the dark mode switch component. It also adds class names to some `<div>` elements in `SiteFooter.tsx` and `SiteHeader.tsx` for better styling and identification.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1f8681e</samp>

> _We are the xloggers, we code with skill and grace_
> _We use class names to style our interface_
> _We make our site accessible and responsive_
> _We switch to dark mode with a simple directive_

### WHY

part of #450 

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1f8681e</samp>

*  Change the site content wrapper to a `<main>` element for better semantics and accessibility ([link](https://github.com/Crossbell-Box/xLog/pull/526/files?diff=unified&w=0#diff-b44279d666bc368a9d8b3c988ed283fa6d4712fcc2ebd9275eed8746faac5d70L162-R162))
*  Add class names to the `<div>` elements that contain the blockchain info, the social platforms icons, and the connect account button for easier styling and identification ([link](https://github.com/Crossbell-Box/xLog/pull/526/files?diff=unified&w=0#diff-b44279d666bc368a9d8b3c988ed283fa6d4712fcc2ebd9275eed8746faac5d70L169-R171), [link](https://github.com/Crossbell-Box/xLog/pull/526/files?diff=unified&w=0#diff-765d257cdb9e99b90862bdf509d92d60910659262e97a25f78e2c48a44847bcfL53-R53), [link](https://github.com/Crossbell-Box/xLog/pull/526/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL336-R336))
*  Import and use the `cn` utility function to simplify the conditional class name logic for the dark mode switch component in `src/components/common/DarkModeSwitch.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/526/files?diff=unified&w=0#diff-a5cebf01f5a3695ff1f69ee076704d693ad21263bdfa158ed24867e8beba2bd9R6), [link](https://github.com/Crossbell-Box/xLog/pull/526/files?diff=unified&w=0#diff-a5cebf01f5a3695ff1f69ee076704d693ad21263bdfa158ed24867e8beba2bd9L14-R18))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
