### PR TITLE
Add remark-emoji render for Markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "remark-breaks": "^3.0.3",
     "remark-directive": "2.0.1",
     "remark-directive-rehype": "0.4.2",
+    "remark-emoji": "^3.1.1",
     "remark-frontmatter": "4.0.1",
     "remark-gfm": "3.0.1",
     "remark-math": "^5.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -286,6 +286,9 @@ dependencies:
   remark-directive-rehype:
     specifier: 0.4.2
     version: 0.4.2
+  remark-emoji:
+    specifier: ^3.1.1
+    version: 3.1.1
   remark-frontmatter:
     specifier: 4.0.1
     version: 4.0.1
@@ -7310,6 +7313,10 @@ packages:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
 
+  /emoticon@4.0.1:
+    resolution: {integrity: sha512-dqx7eA9YaqyvYtUhJwT4rC1HIp82j5ybS1/vQ42ur+jBe17dJMwZE4+gvL1XadSFfxaPFFGt3Xsw+Y8akThDlw==}
+    dev: false
+
   /encode-utf8@1.0.3:
     resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
     dev: false
@@ -10633,6 +10640,12 @@ packages:
     resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
     dev: false
 
+  /node-emoji@1.11.0:
+    resolution: {integrity: sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==}
+    dependencies:
+      lodash: 4.17.21
+    dev: false
+
   /node-fetch@2.6.11:
     resolution: {integrity: sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==}
     engines: {node: 4.x || >=6.0.0}
@@ -11902,6 +11915,15 @@ packages:
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /remark-emoji@3.1.1:
+    resolution: {integrity: sha512-kVCTaHzX+/ls67mE8JsGd3ZX511p2FlAPmKhdGpRCb5z6GSwp+3sAIB5oTySIetPh7CtqfGf7JBUt5fyMjgOHw==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      emoticon: 4.0.1
+      mdast-util-find-and-replace: 2.2.2
+      node-emoji: 1.11.0
     dev: false
 
   /remark-frontmatter@4.0.1:

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -25,6 +25,7 @@ import remarkGfm from "remark-gfm"
 import remarkMath from "remark-math"
 import remarkParse from "remark-parse"
 import remarkRehype from "remark-rehype"
+import emoji from "remark-emoji"
 import { unified } from "unified"
 
 import { Style } from "~/components/common/Style"
@@ -130,6 +131,7 @@ export const renderPageContent = (
       })
       .use(remarkPangu)
       .use(remarkRehype, { allowDangerousHtml: true })
+      .use(emoji)
 
     if (!html) {
       pipeline.use(rehypeCustomWrapper, {


### PR DESCRIPTION
### WHAT
This PR added the rendering functionality for `remark-emoji`, enabling the printing of icons by using the word in Markdown. 
> For example  >>>  ": apple :"(remove the spaces) ---> 🍎 

### WHY
<!-- author to complete -->
[issue525](https://github.com/Crossbell-Box/xLog/issues/525)


### HOW
- install `remark-emoji` dependecy ([link](https://github.com/Crossbell-Box/xLog/pull/528/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R126))
- use `emoji` render for `unified` in `src/markdown/index.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/528/files#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR28), [link](https://github.com/Crossbell-Box/xLog/pull/528/files#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR134))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.

xLog address: 0x8a09fb23e1c8d0ff9c9fef0bcfc9b9e07b1f0667 
xLog web: skyone.xlog.app
Discord ID: skyone#8140
