### PR TITLE
fix: ai_filtering always true

### DIFF
--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -186,7 +186,7 @@ export const HomeFeed: React.FC<{
   const [aiFiltering, setAiFiltering] = useState(true)
 
   useEffect(() => {
-    setAiFiltering(getStorage("ai_filtering")?.enabled || true)
+    setAiFiltering(getStorage("ai_filtering")?.enabled ?? true)
   }, [])
 
   const hotTabs = [


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4c6ec8</samp>

Fixed a bug in `HomeFeed.tsx` that could enable AI filtering of the home feed by default. Used the nullish coalescing operator to set the initial state of `aiFiltering` from local storage.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d4c6ec8</samp>

> _`useEffect` hook_
> _coalesces nullish values_
> _autumn leaves filter_

### WHY
#519

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d4c6ec8</samp>

* Use nullish coalescing operator to set default value of `aiFiltering` state ([link](https://github.com/Crossbell-Box/xLog/pull/538/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dL189-R189))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
