### PR TITLE
fix: comments not render when get empty list

### DIFF
--- a/src/app/dashboard/[subdomain]/comments/page.tsx
+++ b/src/app/dashboard/[subdomain]/comments/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useParams } from "next/navigation"
+import { useEffect } from "react"
 import { Virtuoso } from "react-virtuoso"
 
 import { CommentItem } from "~/components/common/CommentItem"
@@ -8,6 +9,7 @@ import { DashboardMain } from "~/components/dashboard/DashboardMain"
 import { UniLink } from "~/components/ui/UniLink"
 import { getSiteLink } from "~/lib/helpers"
 import { Trans, useTranslation } from "~/lib/i18n/client"
+import { last } from "~/lib/utils"
 import { useGetCommentsBySite, useGetSite } from "~/queries/site"
 
 export default function CommentsPage() {
@@ -20,6 +22,19 @@ export default function CommentsPage() {
   const comments = useGetCommentsBySite({
     characterId: site.data?.characterId,
   })
+
+  // fetch next page when we get a empty list
+  useEffect(() => {
+    if (
+      comments.data?.pages &&
+      last(comments.data.pages)?.list.length === 0 &&
+      comments.hasNextPage
+    ) {
+      comments.fetchNextPage()
+    }
+  }, [comments.data, comments.hasNextPage])
+
+  const data = comments.data?.pages.filter((page) => page.list.length > 0)
 
   const feedUrl =
     getSiteLink({
@@ -47,7 +62,7 @@ export default function CommentsPage() {
             <Virtuoso
               className="xlog-comment-list"
               useWindowScroll
-              data={comments.data?.pages}
+              data={data}
               endReached={() =>
                 comments.hasNextPage && comments.fetchNextPage()
               }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -48,3 +48,8 @@ export const calculateElementTop = (el: HTMLElement) => {
   }
   return top
 }
+
+export function last<T>(array: T[]): T | undefined {
+  const length = array == null ? 0 : array.length
+  return length ? array[length - 1] : undefined
+}


### PR DESCRIPTION
### WHAT
copilot:summary

copilot:poem

### WHY
comment page list may be emty after filter by this code
```js
  const notes = await indexer.getNotes({
    toCharacterId: input.characterId,
    limit: 7,
    includeCharacter: true,
    cursor: input.cursor,
    includeNestedNotes: true,
    nestedNotesDepth: 3 as 3,
    nestedNotesLimit: 20,
  })

  notes.list = notes.list.filter((item) =>
    item.toNote?.metadata?.content?.sources?.includes("xlog"),
  )

  return notes
```

and it will cause comment list render error 

<img width="798" alt="Screenshot 2023-05-13 at 21 55 45" src="https://github.com/Crossbell-Box/xLog/assets/4584859/ef4c290a-c757-48fd-8d85-c924257fbe7c">

### HOW
copilot:walkthrough

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
