### PR TITLE
fix: embedded tweet style

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,7 +185,7 @@
     "husky": "8.0.3",
     "lint-staged": "13.2.2",
     "postcss-import": "15.1.0",
-    "postcss-prune-var": "1.0.5",
+    "postcss-prune-var": "1.1.1",
     "prettier": "2.8.8",
     "prettier-package-json": "2.8.0",
     "prisma": "^4.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -469,8 +469,8 @@ devDependencies:
     specifier: 15.1.0
     version: 15.1.0(postcss@8.4.23)
   postcss-prune-var:
-    specifier: 1.0.5
-    version: 1.0.5
+    specifier: 1.1.1
+    version: 1.1.1
   prettier:
     specifier: 2.8.8
     version: 2.8.8
@@ -10453,6 +10453,13 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
+  /minimatch@9.0.0:
+    resolution: {integrity: sha512-0jJj8AvgKqWN05mrwuqi8QYKx1WmYSUoKSxu5Qhs9prezTz10sxAHGNZe9J9cqIJzta8DWsleh2KaVaLl6Ru2w==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: true
+
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
@@ -11203,8 +11210,10 @@ packages:
       postcss: 8.4.23
       postcss-selector-parser: 6.0.11
 
-  /postcss-prune-var@1.0.5:
-    resolution: {integrity: sha512-wDP2zwerXcyaP2f0XnciqFm7ar7BGlBsptoOvf6NuN7VOSS/Pk5PlvvSkcebKQ5AWs0ydpe1MLdIpOxv/u6Rwg==}
+  /postcss-prune-var@1.1.1:
+    resolution: {integrity: sha512-rQS389fV24ohdWYaMjs5PI9eV4vJr6u8qb/8oijomnvOh9Ceytrr1ZMLBt6bJzhH1eqDrFWceXp9SQ5NUPEwCg==}
+    dependencies:
+      minimatch: 9.0.0
     dev: true
 
   /postcss-selector-parser@6.0.11:

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -2,7 +2,7 @@ module.exports = {
   plugins: {
     "postcss-import": {},
     tailwindcss: {},
-    "postcss-prune-var": {},
+    "postcss-prune-var": { skip: ["node_modules/**"] },
     autoprefixer: {},
   },
 }

--- a/src/components/ui/Tweet.tsx
+++ b/src/components/ui/Tweet.tsx
@@ -8,5 +8,9 @@ const components: TweetComponents = {
 }
 
 export default function Tweet({ id }: { id: string }) {
-  return <ReactTweet id={id} components={components} />
+  return (
+    <div className="flex justify-center">
+      <ReactTweet id={id} components={components} />
+    </div>
+  )
 }

--- a/src/markdown/rehype-tweet.ts
+++ b/src/markdown/rehype-tweet.ts
@@ -21,8 +21,8 @@ export const rehypeTweet: Plugin<Array<void>, Root> = () => (tree) => {
       const match = href.match(tweetRegex)
       if (match && match[0] === href) {
         const tweetId = match[1]
-        node.tagName = "tweet"
-        node.properties = {
+        parent.tagName = "tweet"
+        parent.properties = {
           id: tweetId,
         }
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d5ed8d1</samp>

Updated `postcss-prune-var` and fixed some CSS and HTML issues related to tweet embeds. The changes improve the performance and appearance of the blog posts that use `Tweet` components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d5ed8d1</samp>

> _To fix some bugs in the CSS_
> _We updated `postcss-prune-var` I confess_
> _We also tweaked `rehypeTweet`_
> _To make the embeds look neat_
> _And centered them with `flex justify-center` no less_

### WHY
fix error `<div> cannot appear as a descendant of <p>.`
fix tweet style

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d5ed8d1</samp>

*  Update `postcss-prune-var` dependency to fix CSS variable bug ([link](https://github.com/Crossbell-Box/xLog/pull/547/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L188-R188), [link](https://github.com/Crossbell-Box/xLog/pull/547/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL472-R473), [link](https://github.com/Crossbell-Box/xLog/pull/547/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11206-R11216))
*  Add `minimatch` dependency as a subdependency of `postcss-prune-var` ([link](https://github.com/Crossbell-Box/xLog/pull/547/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR10456-R10462))
*  Configure `postcss-prune-var` plugin to skip pruning variables in `node_modules/**` files ([link](https://github.com/Crossbell-Box/xLog/pull/547/files?diff=unified&w=0#diff-05ed1c7f99e45b485708115502a1e0f28c8547e9a9a29c1b8664f79103cf7873L5-R5))
*  Center tweet embeds in blog posts by wrapping `Tweet` component in a `div` element with `flex justify-center` class ([link](https://github.com/Crossbell-Box/xLog/pull/547/files?diff=unified&w=0#diff-0c55794363137c3ebfebd7d1486446879ac1db4246fd21962e7c7e1c02f7ce5eL11-R15))
*  Fix tweet embed rendering issue by replacing parent node of tweet link with a `tweet` node in `rehypeTweet` function ([link](https://github.com/Crossbell-Box/xLog/pull/547/files?diff=unified&w=0#diff-5c0c9921602d0f079b638201cb558ea587d566dfd53fc5f4d57b4a850f90fff8L24-R25))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
