### PR TITLE
fix: solved FCP flash issue.

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Toaster } from "react-hot-toast"
 import "~/css/main.css"
 import { useAcceptLang } from "~/hooks/useAcceptLang"
 import { APP_DESCRIPTION, APP_NAME, APP_SLOGAN, SITE_URL } from "~/lib/env"
+import { getColorScheme } from "~/lib/get-color-scheme"
 
 import Providers from "./providers"
 
@@ -75,9 +76,10 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   const lang = useAcceptLang()
+  const colorScheme = getColorScheme()
 
   return (
-    <html lang={lang} dir={dir(lang)}>
+    <html lang={lang} dir={dir(lang)} className={colorScheme}>
       <body>
         <Providers lang={lang}>{children}</Providers>
         <Toaster />

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState } from "react"
 import { create } from "zustand"
 
+import {
+  COLOR_SCHEME_DARK,
+  COLOR_SCHEME_LIGHT,
+  DEFAULT_COLOR_SCHEME,
+  IS_DEV,
+} from "~/lib/constants"
 import { noop } from "~/lib/noop"
 import { delStorage, getStorage, setStorage } from "~/lib/storage"
 import { isServerSide } from "~/lib/utils"
@@ -14,7 +20,7 @@ interface IMediaStore {
 
 const useMediaStore = create<IMediaStore>(() => {
   return {
-    isDark: false,
+    isDark: DEFAULT_COLOR_SCHEME === COLOR_SCHEME_DARK,
     toggle: () => void 0,
   }
 })
@@ -31,8 +37,8 @@ const useDarkModeInternal = (
   options: DarkModeConfig,
 ) => {
   const {
-    classNameDark = "dark",
-    classNameLight = "light",
+    classNameDark = COLOR_SCHEME_DARK,
+    classNameLight = COLOR_SCHEME_LIGHT,
     storageKey = darkModeKey,
     element,
   } = options
@@ -160,8 +166,8 @@ const mockElement = {
 
 export const useDarkMode = () => {
   const { toggle, value } = useDarkModeInternal(getStorage(darkModeKey), {
-    classNameDark: "dark",
-    classNameLight: "light",
+    classNameDark: COLOR_SCHEME_DARK,
+    classNameLight: COLOR_SCHEME_LIGHT,
     storageKey: darkModeKey,
     element: (globalThis.document && document.documentElement) || mockElement,
   })
@@ -170,6 +176,12 @@ export const useDarkMode = () => {
     useMediaStore.setState({
       isDark: value,
     })
+    const colorScheme = value ? COLOR_SCHEME_DARK : COLOR_SCHEME_LIGHT
+    const date = new Date()
+    date.setMonth(date.getMonth() + 1)
+    document.cookie = IS_DEV
+      ? `color_scheme=${colorScheme};`
+      : `color_scheme=${colorScheme}; Domain=.xlog.app; Path=/; Secure; HttpOnly; expires=${date.toUTCString()}`
   }, [value])
 
   const onceRef = useRef(false)

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { ColorScheme } from "./types"
+
 export const IS_BROWSER = typeof document !== "undefined"
 
 export const IS_PROD = IS_BROWSER
@@ -10,3 +12,7 @@ export const IS_VERCEL_PREVIEW =
   process.env.VERCEL_ENV === "preview"
 
 export const MAXIMUM_FILE_SIZE = 100 // MB
+
+export const COLOR_SCHEME_DARK = "dark"
+export const COLOR_SCHEME_LIGHT = "light"
+export const DEFAULT_COLOR_SCHEME: ColorScheme = "light"

--- a/src/lib/get-color-scheme.ts
+++ b/src/lib/get-color-scheme.ts
@@ -1,0 +1,7 @@
+import { cookies } from "next/headers"
+
+import { DEFAULT_COLOR_SCHEME } from "./constants"
+import { ColorScheme } from "./types"
+
+export const getColorScheme = () =>
+  (cookies().get("color_scheme")?.value || DEFAULT_COLOR_SCHEME) as ColorScheme

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -106,3 +106,5 @@ export type ExpandedCharacter = CharacterEntity & {
     }
   }
 }
+
+export type ColorScheme = "dark" | "light"


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 466f101</samp>

This pull request adds and refactors the color scheme feature of xLog. It allows the user to choose between a dark or a light mode for the page and stores the preference in a cookie. It also uses types and constants to ensure consistency and readability of the code.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 466f101</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever scheme to match the colors of the page_
> _To the preference of each user, stored in `cookies`_
> _Or else in `DEFAULT_COLOR_SCHEME`, a constant sage._

### WHY
https://github.com/Crossbell-Box/xLog/issues/548

This PR isn't valid for users of the custom domain. However, I think this can serve as a temporary approach for the ".xlog.app" domain.


Before:


https://github.com/Crossbell-Box/xLog/assets/32405058/938bfc6a-4441-4d76-b99e-079c0737dbdd



After:

https://github.com/Crossbell-Box/xLog/assets/32405058/74eb1d9d-69d4-42d8-83a8-ae454c152a13


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 466f101</samp>

*  Add `getColorScheme` function to return user's preferred color scheme ([link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-3107c54eff7dbbe1b67631e1600f8fc97a9babd493d89b56e9bec37e1c7346d6R1-R7))
*  Use `getColorScheme` function in `Layout` component to render appropriate color scheme class name ([link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R8), [link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L78-R82))
*  Define `ColorScheme` type and constants for color scheme values and default value ([link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R109-R110), [link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR1-R2), [link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR15-R18))
*  Refactor `useDarkMode` and `useDarkModeInternal` hooks to use constants and type for color scheme parameters and arguments ([link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0R4-R9), [link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L17-R23), [link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L34-R41), [link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L163-R170))
*  Set `color_scheme` cookie value based on dark mode state in `useDarkMode` hook ([link](https://github.com/Crossbell-Box/xLog/pull/551/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0R179-R184))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
