### PR TITLE
fix: posts/pages tab click error

### DIFF
--- a/src/components/dashboard/PagesManager.tsx
+++ b/src/components/dashboard/PagesManager.tsx
@@ -36,7 +36,7 @@ export const PagesManager: React.FC<{
   const params = useParams()
   const subdomain = params?.subdomain as string
   const site = useGetSite(subdomain)
-  const searchParams = useSearchParams()
+  const searchParams = useSearchParams()!
   const router = useRouter()
   const pathname = usePathname()
 
@@ -83,14 +83,13 @@ export const PagesManager: React.FC<{
   ].map((item) => ({
     text: item.text,
     onClick: () => {
-      const newQuery: Record<string, any> = {
-        ...searchParams,
-        visibility: item.value,
-      }
+      // issue related: https://github.com/vercel/next.js/issues/49245
+      const newQuery = new URLSearchParams(searchParams.toString())
+      newQuery.set("visibility", item.value)
       if (item.value === PageVisibilityEnum.All) {
-        delete newQuery["visibility"]
+        newQuery.delete("visibility")
       }
-      const search = new URLSearchParams(newQuery).toString()
+      const search = newQuery.toString()
       router.push(pathname + "?" + search)
     },
     active: item.value === visibility,
@@ -245,7 +244,7 @@ export const PagesManager: React.FC<{
             currentLength++
             return (
               <Link
-                key={page.transactionHash}
+                key={page.transactionHash || page.draftKey}
                 href={getPageEditLink(page)}
                 className="group relative hover:bg-zinc-100 rounded-lg py-3 px-3 transition-colors -mx-3 flex"
               >


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cecad59</samp>

This pull request enhances the `PagesManager` component by fixing a bug, improving type safety, and ensuring uniqueness. These changes improve the user experience and prevent potential errors when managing pages in the dashboard.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cecad59</samp>

> _Sing, O Muse, of the skillful coder who fixed the bug_
> _That plagued the `PagesManager`, the mighty component of the web,_
> _And who refined the hook of search params, the subtle guide_
> _That typed the inputs well and kept the errors far aside._

### WHY

<img width="549" alt="Screenshot 2023-05-16 at 23 00 34" src="https://github.com/Crossbell-Box/xLog/assets/4584859/50f8fed6-7b8a-46d0-bc1f-c9f0e34f043d">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cecad59</samp>

* Fix query string encoding bug for page visibility filter using `URLSearchParams` API ([link](https://github.com/Crossbell-Box/xLog/pull/553/files?diff=unified&w=0#diff-3c26bc73264ed2baab2eeda5032cf9f4f29c935afe0751099babd66fc3bb5560L86-R92))
* Add `!` operator to assert non-null value of `searchParams` hook ([link](https://github.com/Crossbell-Box/xLog/pull/553/files?diff=unified&w=0#diff-3c26bc73264ed2baab2eeda5032cf9f4f29c935afe0751099babd66fc3bb5560L39-R39))
* Use either `transactionHash` or `draftKey` as `key` prop for page items in `PagesManager.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/553/files?diff=unified&w=0#diff-3c26bc73264ed2baab2eeda5032cf9f4f29c935afe0751099babd66fc3bb5560L248-R247))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
