### PR TITLE
fix: post batch action use wrong id

### DIFF
--- a/src/components/dashboard/PagesManagerBatchSelectActionTab.tsx
+++ b/src/components/dashboard/PagesManagerBatchSelectActionTab.tsx
@@ -14,6 +14,10 @@ import { useCreateOrUpdatePage, useDeletePage } from "~/queries/page"
 
 import { DeleteConfirmationModal } from "./DeleteConfirmationModal"
 
+function getPageId(page: ExpandedNote) {
+  return page.noteId || page.draftKey || 0
+}
+
 export const PagesManagerBatchSelectActionTab: React.FC<{
   isPost: boolean
   isNotxLogContent: boolean
@@ -21,7 +25,7 @@ export const PagesManagerBatchSelectActionTab: React.FC<{
     list: ExpandedNote[]
   }>
   batchSelected: (string | number)[]
-  setBatchSelected: (selected: string[]) => void
+  setBatchSelected: (selected: (string | number)[]) => void
 }> = ({ isPost, isNotxLogContent, pages, batchSelected, setBatchSelected }) => {
   const { t } = useTranslation("dashboard")
 
@@ -39,10 +43,10 @@ export const PagesManagerBatchSelectActionTab: React.FC<{
       text: "Select All",
       onClick: () => {
         // Get all page IDs
-        const allIDs: string[] = []
+        const allIDs: (string | number)[] = []
         pages?.pages.map((page) =>
           page.list?.map((page) => {
-            allIDs.push(page.metadata?.content?.slug || "")
+            allIDs.push(getPageId(page))
           }),
         )
         setBatchSelected(allIDs)
@@ -70,7 +74,7 @@ export const PagesManagerBatchSelectActionTab: React.FC<{
         const selectedPages: ExpandedNote[] = []
         pages?.pages.map((page) =>
           page.list?.map((page) => {
-            if (batchSelected.includes(page.metadata?.content?.slug || "")) {
+            if (batchSelected.includes(getPageId(page))) {
               selectedPages.push(page)
             }
           }),


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fe6c7db</samp>

This pull request enhances the batch select action tab for pages by adding a `getPageId` function that handles different page identifiers and using it in the relevant variables and functions. This affects the file `src/components/dashboard/PagesManagerBatchSelectActionTab.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at fe6c7db</samp>

> _We face the doom of different pages_
> _We need a way to find their ids_
> _We use the `getPageId` function_
> _To unleash the power of batch select_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at fe6c7db</samp>

*  Add `getPageId` function to return a unique identifier for a page, either the noteId, the draftKey, or 0 if neither exists ([link](https://github.com/Crossbell-Box/xLog/pull/554/files?diff=unified&w=0#diff-1836d11835b0595f78b9427ea9ec7b932bf225c72b2677f5e460f23ec9e00fb6R17-R20))
*  Change the type of the `setBatchSelected` function parameter to accept either strings or numbers, to match the type of the `batchSelected` state variable ([link](https://github.com/Crossbell-Box/xLog/pull/554/files?diff=unified&w=0#diff-1836d11835b0595f78b9427ea9ec7b932bf225c72b2677f5e460f23ec9e00fb6L24-R28))
*  Use `getPageId` function to get the page ID for each page in the `allIDs` array, instead of using the slug property, which may not exist for some pages ([link](https://github.com/Crossbell-Box/xLog/pull/554/files?diff=unified&w=0#diff-1836d11835b0595f78b9427ea9ec7b932bf225c72b2677f5e460f23ec9e00fb6L42-R49))
*  Use `getPageId` function to check if a page is included in the `batchSelected` array, instead of using the slug property, which may not exist for some pages ([link](https://github.com/Crossbell-Box/xLog/pull/554/files?diff=unified&w=0#diff-1836d11835b0595f78b9427ea9ec7b932bf225c72b2677f5e460f23ec9e00fb6L73-R77))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
