### PR TITLE
fix(ci): next analysis find comment step

### DIFF
--- a/.github/workflows/comment-pr.yml
+++ b/.github/workflows/comment-pr.yml
@@ -46,7 +46,7 @@ jobs:
         id: fc
         with:
           issue-number: ${{ steps.pr.outputs.id }}
-          body-includes: "<!-- __NEXTJS_BUNDLE -->"
+          body-includes: "<!-- __NEXTJS_BUNDLE_xlog -->"
 
       - name: Create Comment
         uses: peter-evans/create-or-update-comment@v2


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77c9bb2</samp>

Fixed the GitHub workflow for commenting bundle analysis reports on pull requests. This improves the readability and accuracy of the comments with `.github/workflows/comment-pr.yml`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 77c9bb2</samp>

> _When pull requests need some inspection_
> _We use bundle analysis for detection_
> _But the comment mode was wrong_
> _And the marker was too long_
> _So we fixed them for better correction_

### WHY

Eliminate unnecessary comments which created by next analysis ci when pr every updated.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 77c9bb2</samp>

* Update the comment marker and edit mode for the bundle analysis report comment ([link](https://github.com/Crossbell-Box/xLog/pull/558/files?diff=unified&w=0#diff-8139aab9304ee2720ec86e2132e5e41017a75cec0ad5ba50e1cb543aa7c65f13L49-R49), [link](https://github.com/Crossbell-Box/xLog/pull/558/files?diff=unified&w=0#diff-8139aab9304ee2720ec86e2132e5e41017a75cec0ad5ba50e1cb543aa7c65f13L65-R65))

