### PR TITLE
feat: support sitemap

### DIFF
--- a/src/app/site/[site]/sitemap.xml/route.ts
+++ b/src/app/site/[site]/sitemap.xml/route.ts
@@ -18,6 +18,7 @@ export const GET = async (req: NextRequest) => {
   // find innei-5425 site handle by regexp
   const domainOrSubdomain =
     req.nextUrl.pathname.match(/\/site\/(.*)\/sitemap.xml/)?.[1] ||
+    req.headers.get("x-handle") ||
     // http://innei-4525.localhost:2222/sitemap.xml
     req.headers.get("host")?.split(".")[0] ||
     ""
@@ -29,6 +30,7 @@ export const GET = async (req: NextRequest) => {
   }
 
   const site = await fetchGetSite(domainOrSubdomain, queryClient)
+
   const pages = await fetchGetPagesBySite(
     {
       characterId: site?.characterId,

--- a/src/app/site/[site]/sitemap.xml/route.ts
+++ b/src/app/site/[site]/sitemap.xml/route.ts
@@ -1,0 +1,58 @@
+import dayjs from "dayjs"
+import { NextRequest } from "next/server"
+
+import { QueryClient } from "@tanstack/react-query"
+
+import { getSiteLink } from "~/lib/helpers"
+import { NextServerResponse } from "~/lib/server-helper"
+import { PageVisibilityEnum } from "~/lib/types"
+import { fetchGetPagesBySite } from "~/queries/page.server"
+import { fetchGetSite } from "~/queries/site.server"
+
+export const GET = async (req: NextRequest) => {
+  const response = new NextServerResponse()
+
+  const queryClient = new QueryClient()
+  // http://localhost:2222/site/innei-4525/sitemap.xml
+  // http://innei-4525.localhost:2222/sitemap.xml
+  // find innei-5425 site handle by regexp
+  const domainOrSubdomain =
+    req.nextUrl.pathname.match(/\/site\/(.*)\/sitemap.xml/)?.[1] ||
+    // http://innei-4525.localhost:2222/sitemap.xml
+    req.headers.get("host")?.split(".")[0] ||
+    ""
+
+  if (!domainOrSubdomain) {
+    return response.status(400).json({
+      message: "domainOrSubdomain is not validate",
+    })
+  }
+
+  const site = await fetchGetSite(domainOrSubdomain, queryClient)
+  const pages = await fetchGetPagesBySite(
+    {
+      characterId: site?.characterId,
+      type: "post",
+      visibility: PageVisibilityEnum.Published,
+    },
+    queryClient,
+  )
+
+  const link = getSiteLink({
+    subdomain: site?.handle || "",
+  })
+  return response.headers({
+    "Content-Type": "text/xml",
+    "Access-Control-Allow-Methods": "GET",
+    "Access-Control-Allow-Origin": "*",
+  }).text(`<?xml version="1.0" encoding="UTF-8"?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ${pages.list?.map((page) => {
+    return `  <url>
+      <loc>${link}/${page.metadata.content.slug}</loc>
+      <lastmod>${dayjs(page.updatedAt).format("YYYY-MM-DD")}</lastmod>
+    </url>`
+  }).join(`
+  `)}
+  </urlset>`)
+}

--- a/src/lib/server-helper.ts
+++ b/src/lib/server-helper.ts
@@ -15,6 +15,7 @@ export const getQuery = (req: Request) => {
 
 export class NextServerResponse {
   #status: number = 200
+  #headers = new Headers()
   constructor() {}
 
   status(status: number) {
@@ -25,12 +26,9 @@ export class NextServerResponse {
   json(data: any) {
     const nextData = JSON.stringify(data)
 
-    return new Response(nextData, {
-      status: this.#status,
-      headers: {
-        "Content-Type": "application/json",
-      },
-    })
+    this.#headers.set("Content-Type", "application/json")
+
+    return new Response(nextData, this.makeResponseOptions())
   }
 
   send(data: any) {
@@ -42,11 +40,23 @@ export class NextServerResponse {
       return this.json(data)
     }
 
-    return new Response(data, { status: this.#status })
+    return new Response(data, this.makeResponseOptions())
+  }
+
+  text(text: string) {
+    return new Response(text, this.makeResponseOptions())
   }
 
   end() {
-    return new Response("", { status: this.#status })
+    return new Response("", this.makeResponseOptions())
+  }
+
+  headers(headers: Record<string, string>) {
+    for (const [key, value] of Object.entries(headers)) {
+      this.#headers.set(key, value)
+    }
+
+    return this
   }
 
   rss(data: any, format = "json") {
@@ -70,6 +80,13 @@ export class NextServerResponse {
           "Cache-Control": "public, max-age=1800",
         },
       })
+    }
+  }
+
+  private makeResponseOptions() {
+    return {
+      status: this.#status,
+      headers: this.#headers,
     }
   }
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -56,8 +56,7 @@ export default async function middleware(req: NextRequest) {
     pathname.match(/^\/(workbox|worker|fallback)-\w+\.js(\.map)?$/) ||
     pathname === "/sw.js" ||
     pathname === "/sw.js.map" ||
-    pathname === "/robots.txt" ||
-    pathname === "/sitemap.xml"
+    pathname === "/robots.txt"
   ) {
     return NextResponse.next()
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -83,6 +83,7 @@ export default async function middleware(req: NextRequest) {
   const requestHeaders = new Headers(req.headers)
   requestHeaders.set("x-pathname", req.nextUrl.pathname)
   requestHeaders.set("x-search", req.nextUrl.search)
+  requestHeaders.set("x-handle", tenant.subdomain || "")
 
   if (tenant?.subdomain) {
     const url = req.nextUrl.clone()


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2784a75</samp>

This pull request adds support for generating and serving dynamic sitemap.xml files for each site in the Crossbell-Box/xLog app. It also improves the `NextServerResponse` class to handle custom headers and text responses, and cleans up some unused code in the `middleware.ts` file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2784a75</samp>

> _We are the masters of the sitemap_
> _We fetch the data with the `queryClient`_
> _We set the headers and the text response_
> _We bypass the middleware with our might_

### WHY

Support sitemap in app router

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2784a75</samp>

*  Add a new route handler for the sitemap.xml file for each site ([link](https://github.com/Crossbell-Box/xLog/pull/559/files?diff=unified&w=0#diff-87e647d89a99a35f053f98e965b14656de85c5aca19532be779dc67410624862R1-R58))
*  Refactor the `NextServerResponse` class in `server-helper.ts` to support custom headers ([link](https://github.com/Crossbell-Box/xLog/pull/559/files?diff=unified&w=0#diff-59102566004aa11373940ed74936c88f94b12fe12bce3910598cdc2f553ae738R18), [link](https://github.com/Crossbell-Box/xLog/pull/559/files?diff=unified&w=0#diff-59102566004aa11373940ed74936c88f94b12fe12bce3910598cdc2f553ae738L28-R31), [link](https://github.com/Crossbell-Box/xLog/pull/559/files?diff=unified&w=0#diff-59102566004aa11373940ed74936c88f94b12fe12bce3910598cdc2f553ae738L45-R61), [link](https://github.com/Crossbell-Box/xLog/pull/559/files?diff=unified&w=0#diff-59102566004aa11373940ed74936c88f94b12fe12bce3910598cdc2f553ae738R85-R91))
*  Remove the condition to bypass the custom middleware for the sitemap.xml file in `middleware.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/559/files?diff=unified&w=0#diff-0626369278c89781505d2c04865ecce1302e979271bcfb471e029c19addc13a0L59-R59))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
