### PR TITLE
fix: github repo embed

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     ]
   },
   "dependencies": {
-    "@birdgg/react-github": "0.2.2",
+    "@birdgg/react-github": "0.2.3",
     "@codemirror/commands": "6.2.4",
     "@codemirror/lang-markdown": "6.1.1",
     "@codemirror/language": "6.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@birdgg/react-github':
-    specifier: 0.2.2
-    version: 0.2.2(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.2.3
+    version: 0.2.3(react-dom@18.2.0)(react@18.2.0)
   '@codemirror/commands':
     specifier: 6.2.4
     version: 6.2.4
@@ -1713,8 +1713,8 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
-  /@birdgg/react-github@0.2.2(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-mBiLK5str0duFrBCCzGaNAkBP9yuxIq04cnGUmNHpfuYLrPyt18o8d13Gt9zAFjKkLOTg4J4yWoKaQwCCI8DCQ==}
+  /@birdgg/react-github@0.2.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-VIwpLdZYf/oiRneMmkwiQU3F9TmuSgfZ1bp2IImeCB3xwyVYIkjTY41gh1XkQoidLdiS4J35FUmibJxgpiLjoQ==}
     peerDependencies:
       react: '>= 18.0.0'
       react-dom: '>= 18.0.0'

--- a/src/markdown/embed-transformers/index.ts
+++ b/src/markdown/embed-transformers/index.ts
@@ -1,7 +1,7 @@
 import type { Transformer } from "../rehype-embed"
 import { BilibiliTransformer } from "./Bilibili"
 import { CodeSandboxTransformer } from "./CodeSandBox"
-// import { GitHubRepoTransformer } from "./GitHub"
+import { GitHubRepoTransformer } from "./GitHub"
 import { NetEaseMusicTransformer } from "./NetEaseMusic"
 import { TweetTransformer } from "./Tweet"
 import { YouTubeTransformer } from "./YouTube"
@@ -9,7 +9,7 @@ import { YouTubeTransformer } from "./YouTube"
 export const transformers: Transformer[] = [
   CodeSandboxTransformer,
   TweetTransformer,
-  // GitHubRepoTransformer,
+  GitHubRepoTransformer,
   YouTubeTransformer,
   NetEaseMusicTransformer,
   BilibiliTransformer,

--- a/src/markdown/rehype-embed.ts
+++ b/src/markdown/rehype-embed.ts
@@ -20,8 +20,7 @@ export const rehypeEmbed: Plugin<
         !parent ||
         !("tagName" in parent) ||
         parent.tagName !== "p" ||
-        parent.children.length > 1 ||
-        (node.children?.[0] as any)?.value !== node.properties?.href
+        parent.children.length > 1
       )
         return
 

--- a/src/markdown/rehype-embed.ts
+++ b/src/markdown/rehype-embed.ts
@@ -20,7 +20,8 @@ export const rehypeEmbed: Plugin<
         !parent ||
         !("tagName" in parent) ||
         parent.tagName !== "p" ||
-        parent.children.length > 1
+        parent.children.length > 1 ||
+        (node.children?.[0] as any)?.value !== node.properties?.href
       )
         return
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0370070</samp>

This pull request adds a new feature to embed GitHub repositories in the markdown editor. It updates the dependency `@birdgg/react-github` and modifies the `rehype-embed` plugin and the `embed-transformers` module to enable this feature.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 0370070</samp>

> _Sing, O Muse, of the skillful coder who updated the package_
> _That renders the glorious deeds of GitHub heroes in markdown_
> _Heeding not the faulty condition that hindered the transformation_
> _But removing it with swift fingers, like Zeus hurling his thunderbolt_

### WHY
update @birdgg/react-github package to fix crash when language or description is null

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0370070</samp>

*  Update `@birdgg/react-github` dependency to version 0.2.3 in `package.json` and `pnpm-lock.yaml` ([link](https://github.com/Crossbell-Box/xLog/pull/570/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L31-R31), [link](https://github.com/Crossbell-Box/xLog/pull/570/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5-R6), [link](https://github.com/Crossbell-Box/xLog/pull/570/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1716-R1717))
*  Import and export `GitHubRepoTransformer` from `./GitHub` in `src/markdown/embed-transformers/index.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/570/files?diff=unified&w=0#diff-e3637a5c2e98e8664cfee1156e9d6085cbf5237a3d74c01b324367680996f397L4-R4), [link](https://github.com/Crossbell-Box/xLog/pull/570/files?diff=unified&w=0#diff-e3637a5c2e98e8664cfee1156e9d6085cbf5237a3d74c01b324367680996f397L12-R12))
*  Remove condition that prevents GitHub repository links from being transformed into embeds in `src/markdown/rehype-embed.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/570/files?diff=unified&w=0#diff-bd040d577d240ff4d76d4a76b53516403dd1ec107eab84a930ba828f853f50a8L23-R23))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
