### PR TITLE
feat: add skeleton loading for home feed

### DIFF
--- a/src/components/common/CharacterCard.tsx
+++ b/src/components/common/CharacterCard.tsx
@@ -2,6 +2,7 @@ import { FollowingButton } from "~/components/common/FollowingButton"
 import { FollowingCount } from "~/components/common/FollowingCount"
 import { Titles } from "~/components/common/Titles"
 import { Avatar } from "~/components/ui/Avatar"
+import { Skeleton } from "~/components/ui/Skeleton"
 import { useDate } from "~/hooks/useDate"
 import { useTranslation } from "~/lib/i18n/client"
 import { cn } from "~/lib/utils"
@@ -97,7 +98,15 @@ export const CharacterCard: React.FC<{
           )}
         </>
       ) : (
-        <>{t("Loading")}...</>
+        <Skeleton.Container className={cn(simple ? "space-y-1" : "space-y-2")}>
+          <div className="flex justify-between items-center">
+            <Skeleton.Circle size={40} />
+            <Skeleton.Rectangle className="h-7 w-24" />
+          </div>
+          <Skeleton.Rectangle className="w-2/3" />
+          <Skeleton.Rectangle className="my-4 w-full h-16" />
+          <Skeleton.Rectangle className="w-1/2" />
+        </Skeleton.Container>
       )}
     </span>
   )

--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -24,6 +24,7 @@ import type { FeedType, SearchType } from "~/models/home.model"
 import { useGetFeed } from "~/queries/home"
 
 import { EmptyState } from "../ui/EmptyState"
+import { Skeleton } from "../ui/Skeleton"
 
 const PostCard = ({
   post,
@@ -337,7 +338,7 @@ export const HomeFeed: React.FC<{
         )}
 
         {feed.isLoading ? (
-          <div className="text-center text-zinc-600">{t("Loading")}...</div>
+          <FeedSkeleton />
         ) : !feed.data?.pages[0]?.count ? (
           <EmptyState />
         ) : (
@@ -388,5 +389,21 @@ const Loader = () => {
     >
       {t("Loading")} ...
     </div>
+  )
+}
+
+const FeedSkeleton = () => {
+  return (
+    <Skeleton.Container count={5} className="space-y-8">
+      <div>
+        <div className="flex space-x-2 items-center">
+          <Skeleton.Circle size={40} />
+          <Skeleton.Rectangle className="w-1/3" />
+        </div>
+        <div className="py-4 pr-4 ml-12">
+          <Skeleton.Rectangle className="w-full h-24" />
+        </div>
+      </div>
+    </Skeleton.Container>
   )
 }

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,87 @@
+"use client"
+
+import React, { PropsWithChildren, useMemo } from "react"
+
+import { useTranslation } from "~/lib/i18n/client"
+import { cn } from "~/lib/utils"
+
+interface Props {
+  className?: string
+  width?: number | string
+  height?: number | string
+}
+
+const skeletonColor = "bg-gray-200 dark:bg-gray-700"
+
+function unit(unit: string | number | undefined) {
+  if (!unit) return
+  return typeof unit === "number" ? `${unit}px` : unit
+}
+
+export function Skeleton({ className, width, height }: Props) {
+  const sizeObj = useMemo(() => {
+    const _size: any = {}
+    let _className = []
+    width ? (_size.width = unit(width)) : _className.push("w-full")
+    height ? (_size.height = unit(height)) : _className.push("h-4")
+    return {
+      style: _size,
+      className: _className.join(" "),
+    }
+  }, [width, height])
+
+  return (
+    <div
+      className={cn(skeletonColor, sizeObj.className, className)}
+      style={sizeObj.style}
+    />
+  )
+}
+
+function Container({
+  count = 1,
+  className,
+  children,
+}: PropsWithChildren<{ count?: number; className?: string }>) {
+  const { t } = useTranslation("common")
+  const childrenArray = React.Children.toArray(children)
+
+  return (
+    <div role="status" className={cn("animate-pulse", className)}>
+      {Array.from(new Array(count)).map((_, index) => (
+        <React.Fragment key={index}>
+          {childrenArray.map((child) =>
+            React.cloneElement(child as React.ReactElement<any>, {
+              key: index,
+            }),
+          )}
+        </React.Fragment>
+      ))}
+      <span className="sr-only">{t("Loading")}...</span>
+    </div>
+  )
+}
+
+function Circle({
+  size = 40,
+  className,
+}: {
+  size?: number
+  className?: string
+}) {
+  return (
+    <Skeleton
+      className={cn("rounded-full", className)}
+      width={size}
+      height={size}
+    />
+  )
+}
+
+function Rectangle({ className }: { className?: string }) {
+  return <Skeleton className={cn("rounded", className)} />
+}
+
+Skeleton.Container = Container
+Skeleton.Circle = Circle
+Skeleton.Rectangle = Rectangle


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1968622</samp>

Added a `Skeleton` component to create loading states for the UI. The `Skeleton` component can be used in different components, such as `CharacterCard` and `HomeFeed`, to show placeholder elements while fetching data. The `Skeleton` component also supports accessibility features.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 1968622</samp>

> _Oh we are the coders of the sea_
> _And we build the UI with `Skeleton`_
> _We make it look nice while we fetch the data_
> _Heave away, heave away, heave away me hearties_

### WHY

https://github.com/Crossbell-Box/xLog/assets/4584859/c0394549-f86d-4c4a-83bc-cdf093683082

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1968622</samp>

*  Import and use `Skeleton` component to display loading states for `CharacterCard` and `HomeFeed` components ([link](https://github.com/Crossbell-Box/xLog/pull/574/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cR5), [link](https://github.com/Crossbell-Box/xLog/pull/574/files?diff=unified&w=0#diff-10ab4ab600f7a870caef35b5821e82f0c9a34f9b2db1c2e61a1448215221526cL100-R109), [link](https://github.com/Crossbell-Box/xLog/pull/574/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dR27), [link](https://github.com/Crossbell-Box/xLog/pull/574/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dL340-R341))
*  Define `FeedSkeleton` component to render placeholder feed items using `Skeleton` subcomponents ([link](https://github.com/Crossbell-Box/xLog/pull/574/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dR394-R409))
*  Add `Skeleton` component file to `src/components/ui` folder with three subcomponents: `Skeleton.Container`, `Skeleton.Circle`, and `Skeleton.Rectangle` ([link](https://github.com/Crossbell-Box/xLog/pull/574/files?diff=unified&w=0#diff-68485ff79457de3bc8ecd3af2c8798018a44d64639ae200f63dc67dcb4df37eeR1-R87))
*  Use `useTranslation` hook to provide accessible text for screen readers in `Skeleton` component ([link](https://github.com/Crossbell-Box/xLog/pull/574/files?diff=unified&w=0#diff-68485ff79457de3bc8ecd3af2c8798018a44d64639ae200f63dc67dcb4df37eeR1-R87))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
