### PR TITLE
fix: toc href not match id

### DIFF
--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -124,9 +124,6 @@ export const renderPageContent = (
           }
         }
       })
-      .use(() => (tree) => {
-        env.toc = toc(tree, { tight: true, ordered: true })
-      })
       .use(remarkGfm, {
         singleTilde: false,
       })
@@ -139,6 +136,9 @@ export const renderPageContent = (
         singleDollarTextMath: false,
       })
       .use(remarkPangu)
+      .use(() => (tree) => {
+        env.toc = toc(tree, { tight: true, ordered: true })
+      })
       .use(remarkRehype, { allowDangerousHtml: true })
       .use(emoji)
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04c143e</samp>

Fix markdown toc bug in `src/markdown/index.ts`. Adjust remark plugin order to match heading levels.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 04c143e</samp>

> _Oh, we're the jolly coders of the markdown sea_
> _We fix the bugs and make the pages look pretty_
> _We heave and ho and change the remark plugins_
> _To make the toc reflect the headings within_

### WHY
toc href may not match header id because of pangujs

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04c143e</samp>

* Remove and re-add the toc plugin to fix rendering error ([link](https://github.com/Crossbell-Box/xLog/pull/575/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcL127-L129), [link](https://github.com/Crossbell-Box/xLog/pull/575/files?diff=unified&w=0#diff-733efe578c40ff2e6b0770350d988ec422a6d3ad9f1543b2bcda58e0ed546fdcR139-R141))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
