### PR TITLE
chore: group renovate prs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base", "group:allNonMajor", "group:codemirror"],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
@@ -19,10 +17,6 @@
       "automerge": true
     }
   ],
-  "automergeSchedule": [
-    "before 2am"
-  ],
-  "schedule": [
-    "before 2am"
-  ]
+  "automergeSchedule": ["before 2am"],
+  "schedule": ["before 2am"]
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a6a44b</samp>

Updated `renovate.json` to improve dependency update management and readability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5a6a44b</samp>

> _We face the doom of outdated code_
> _We must resist the breaking changes_
> _We group our updates by dependency_
> _We reformat our schedules for clarity_

### WHY

Group renovate's pr. In order to make the Pull Request board tidier.

https://docs.renovatebot.com/presets-group/#groupallnonmajor

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a6a44b</samp>

*  Add two presets to `extends` array to group non-major and codemirror updates ([link](https://github.com/Crossbell-Box/xLog/pull/581/files?diff=unified&w=0#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L3-R3))
*  Reformat `automergeSchedule` and `schedule` arrays to use single line ([link](https://github.com/Crossbell-Box/xLog/pull/581/files?diff=unified&w=0#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57L22-R21))

