### PR TITLE
Update apple-app-site-association

### DIFF
--- a/public/.well-known/apple-app-site-association
+++ b/public/.well-known/apple-app-site-association
@@ -1,6 +1,11 @@
 {
   "applinks": {
+    "apps": [], // This is usually left empty, but still must be included
     "details": [
+      {
+        "appID": "9AYPRU93J4.com.crossbell.xlog",
+        "paths": ["/*"]
+      },
       {
         "appIDs": ["9AYPRU93J4.com.crossbell.xlog"],
         "components": [


### PR DESCRIPTION
Modify the AASA verification file.

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4ed2469</samp>

Added universal links support for iOS apps. Updated `apple-app-site-association` file with the new format and identifiers for the main and legacy apps.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4ed2469</samp>

> _`apple-app-site-association` is the key to the gate_
> _Universal links for the apps of old and new_
> _We use the latest format to seal our fate_
> _The `apps` key is the sign of the chosen few_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4ed2469</samp>

*  Update `apple-app-site-association` file to use latest format for universal links ([link](https://github.com/Crossbell-Box/xLog/pull/582/files?diff=unified&w=0#diff-78cf5dcb996fc69d5c14c473cc0076aa286a7a919db6442d32e3d9bb4da89e23L3-R9))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
