### PR TITLE
fix: HttpOnly not support to config on client js

### DIFF
--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -206,7 +206,7 @@ export const useDarkMode = () => {
     date.setMonth(date.getMonth() + 1)
     document.cookie = IS_DEV
       ? `color_scheme=${colorScheme};`
-      : `color_scheme=${colorScheme}; Domain=.${OUR_DOMAIN}; Path=/; Secure; HttpOnly; expires=${date.toUTCString()}`
+      : `color_scheme=${colorScheme}; Domain=.${OUR_DOMAIN}; Path=/; Secure; expires=${date.toUTCString()}`
   }, [value])
 
   const onceRef = useRef(false)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3584779</samp>

Fixed dark mode persistence bug by allowing JavaScript access to the color scheme cookie in `useDarkMode` hook.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3584779</samp>

> _`HttpOnly` gone_
> _Cookie reveals dark mode choice_
> _Style persists in fall_

### WHY
#584 

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3584779</samp>

* Remove `HttpOnly` attribute from cookie setting in `useDarkMode` hook to allow client-side access to color scheme preference ([link](https://github.com/Crossbell-Box/xLog/pull/585/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L209-R209))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
