### PR TITLE
feat: spotify embed

### DIFF
--- a/src/markdown/embed-transformers/Spotify.ts
+++ b/src/markdown/embed-transformers/Spotify.ts
@@ -1,0 +1,47 @@
+import type { Transformer } from "../rehype-embed"
+import { generateIframeHTML, includesSomeOfArray } from "./utils"
+
+const getSpotifyIFrameSrc = (url: URL) => {
+  const { pathname } = url
+  const urlString = url.toString()
+  const type = pathname.split("/")[1].toLowerCase()
+
+  const podcastTypes = ["episode", "show"]
+  if (podcastTypes.includes(type)) {
+    return urlString.replace(type, `embed-podcast/${type}`)
+  }
+
+  return urlString.replace(type, `embed/${type}`)
+}
+
+export const SpotifyTransformer: Transformer = {
+  name: "Spotify",
+  shouldTransform(url) {
+    const { host, pathname } = url
+
+    return (
+      host === "open.spotify.com" &&
+      !includesSomeOfArray(pathname, ["embed", "embed-podcast"]) &&
+      includesSomeOfArray(pathname, [
+        "/album/",
+        "/artist/",
+        "/episode/",
+        "/show/",
+        "/track/",
+        "/playlist/",
+      ])
+    )
+  },
+  getHTML(url) {
+    const iframe = getSpotifyIFrameSrc(url)
+    return generateIframeHTML({
+      name: "spotify",
+      src: iframe,
+      height: "152px",
+      width: "100%",
+      style: "border-radius: 12px;",
+      allow:
+        "accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture",
+    })
+  },
+}

--- a/src/markdown/embed-transformers/index.ts
+++ b/src/markdown/embed-transformers/index.ts
@@ -3,6 +3,7 @@ import { BilibiliTransformer } from "./Bilibili"
 import { CodeSandboxTransformer } from "./CodeSandBox"
 import { GitHubRepoTransformer } from "./GitHub"
 import { NetEaseMusicTransformer } from "./NetEaseMusic"
+import { SpotifyTransformer } from "./Spotify"
 import { TweetTransformer } from "./Tweet"
 import { YouTubeTransformer } from "./YouTube"
 
@@ -13,4 +14,5 @@ export const transformers: Transformer[] = [
   YouTubeTransformer,
   NetEaseMusicTransformer,
   BilibiliTransformer,
+  SpotifyTransformer,
 ]

--- a/src/markdown/embed-transformers/utils.ts
+++ b/src/markdown/embed-transformers/utils.ts
@@ -1,8 +1,11 @@
 import { IframeHTMLAttributes } from "react"
 
-interface IframeProps extends IframeHTMLAttributes<HTMLIFrameElement> {
+interface IframeProps
+  extends Omit<IframeHTMLAttributes<HTMLIFrameElement>, "style"> {
   name: string
   ratio?: string
+  /** inline style string */
+  style?: string
 }
 
 export const isHostIncludes = (domain: string, host: string) => {
@@ -18,7 +21,6 @@ export const generateIframeHTML = ({
   height,
   width,
   ratio,
-  style,
   ...attributes
 }: IframeProps) => {
   const iframeAttributes = Object.entries(attributes)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at daf7919</samp>

Added support for embedding Spotify content in markdown files. Implemented a new `SpotifyTransformer` object in `src/markdown/embed-transformers/Spotify.ts` and integrated it with the existing `rehype-embed` plugin.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at daf7919</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous transformer for the songs of Spotify,_
> _That he might embed them in his xLog with ease_
> _And delight his readers with melodious variety._

### WHY

<img width="1091" alt="Screenshot 2023-05-26 at 02 33 06" src="https://github.com/Crossbell-Box/xLog/assets/4584859/2e855c0b-f23c-443a-9b8e-a56976a86a8d">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at daf7919</samp>

*  Add support for embedding Spotify content in markdown files ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-e3637a5c2e98e8664cfee1156e9d6085cbf5237a3d74c01b324367680996f397R6), [link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-e3637a5c2e98e8664cfee1156e9d6085cbf5237a3d74c01b324367680996f397R17), [link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-0c899252df85c3b91e3a73126c47a54972c223a4bcb32e289e0ad20366a31969R1-R47))
  * Import `SpotifyTransformer` from `Spotify.ts` in `index.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-e3637a5c2e98e8664cfee1156e9d6085cbf5237a3d74c01b324367680996f397R6))
  * Export `SpotifyTransformer` in the array of transformers in `index.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-e3637a5c2e98e8664cfee1156e9d6085cbf5237a3d74c01b324367680996f397R17))
  * Create `Spotify.ts` file that exports `SpotifyTransformer` object ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-0c899252df85c3b91e3a73126c47a54972c223a4bcb32e289e0ad20366a31969R1-R47))
    * Define `shouldTransform` function that checks if URL is from Spotify and has valid content type ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-0c899252df85c3b91e3a73126c47a54972c223a4bcb32e289e0ad20366a31969R1-R47))
    * Define `getHTML` function that returns iframe HTML string with appropriate source and attributes for Spotify content ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-0c899252df85c3b91e3a73126c47a54972c223a4bcb32e289e0ad20366a31969R1-R47))
    * Define `getSpotifyIFrameSrc` function that converts Spotify URL to embeddable iframe URL ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-0c899252df85c3b91e3a73126c47a54972c223a4bcb32e289e0ad20366a31969R1-R47))
* Modify `IframeProps` interface and `generateIframeHTML` function in `utils.ts` to allow custom style string for iframe elements ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-778db970fbe15bd507d6756dc7fb647b876db3e51a766ee36562c56b15625eb5L3-R8), [link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-778db970fbe15bd507d6756dc7fb647b876db3e51a766ee36562c56b15625eb5L21))
  * Add `style` property to `IframeProps` interface as a string ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-778db970fbe15bd507d6756dc7fb647b876db3e51a766ee36562c56b15625eb5L3-R8))
  * Omit `style` property from `IframeHTMLAttributes` type to avoid type conflict ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-778db970fbe15bd507d6756dc7fb647b876db3e51a766ee36562c56b15625eb5L3-R8))
  * Remove `style` property from `generateIframeHTML` function and pass it as part of `...rest` spread operator ([link](https://github.com/Crossbell-Box/xLog/pull/586/files?diff=unified&w=0#diff-778db970fbe15bd507d6756dc7fb647b876db3e51a766ee36562c56b15625eb5L21))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
