### PR TITLE
fix: remove comment count if it's reply button

### DIFF
--- a/src/components/common/CommentItem.tsx
+++ b/src/components/common/CommentItem.tsx
@@ -122,9 +122,11 @@ export const CommentItem: React.FC<{
                 onClick={() => setReplyOpen(!replyOpen)}
               >
                 {t(`${replyOpen ? "Cancel " : ""}Reply`)}
-                <span className="ml-1">
-                  {(comment as any)?.fromNotes?.count || 0}
-                </span>
+                {!replyOpen && (
+                  <span className="ml-1">
+                    {(comment as any)?.fromNotes?.count || 0}
+                  </span>
+                )}
               </Button>
             )}
             {comment.characterId === account?.characterId && (


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 52d8211</samp>

Improve comment UI by hiding note count when replying. Update `CommentItem.tsx` component to implement this logic.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 52d8211</samp>

> _`reply` toggled off_
> _show notes count on comment_
> _autumn leaves falling_

### WHY
<img width="822" alt="CleanShot 2023-05-26 at 5 32 42@2x" src="https://github.com/Crossbell-Box/xLog/assets/41265413/b4210483-0b25-468b-9d51-bd2653ebb13d">


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 52d8211</samp>

*  Add a condition to only show the number of notes on a comment when the reply button is not toggled ([link](https://github.com/Crossbell-Box/xLog/pull/590/files?diff=unified&w=0#diff-2f7374e2a6026a149faa9877018aa0e55e80af0c166db4296176ccc910a84fbfL125-R129))
