### PR TITLE
feat: enhance print mode style

### DIFF
--- a/src/css/print.css
+++ b/src/css/print.css
@@ -2,6 +2,10 @@
   nav,
   header,
   footer,
+  .xlog-post-views,
+  .xlog-post-editor,
+  .xlog-post-toc,
+  .xlog-post-actions,
   *[data-hide-print] {
     display: none !important;
   }

--- a/src/css/print.css
+++ b/src/css/print.css
@@ -1,4 +1,11 @@
 @media print {
+  /* Copied from https://stackoverflow.com/a/44908040 */
+  * {
+    -webkit-print-color-adjust: exact !important;
+    color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
   nav,
   header,
   footer,


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cb209cb</samp>

The pull request enhances the print style of the blog posts by hiding some elements that are only relevant for the web version. It adds four new classes to `src/css/print.css` for this purpose.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cb209cb</samp>

> _`print` media query_
> _hides four classes from blog posts_
> _autumn leaves fall clean_

### WHY
<!-- author to complete -->

Before:

![image](https://github.com/Crossbell-Box/xLog/assets/30072175/8e2141a5-0b7f-4136-9536-f1db6aac58d5)

After:

![image](https://github.com/Crossbell-Box/xLog/assets/30072175/17711d35-c8f2-4520-b42e-823ff34aaa7d)

### HOW

Apply these style changes to print mode:

+ Hide `xlog-post-views`, `xlog-post-editor`, `xlog-post-toc`, `xlog-post-actions`
+ Force enable background colors or images

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cb209cb</samp>

*  Hide non-essential elements from print view by adding four classes to `print.css` ([link](https://github.com/Crossbell-Box/xLog/pull/592/files?diff=unified&w=0#diff-58151cb4361cb5e6a15f341ce7611d40d466add2189860d27731b7072c4bcad5R5-R8))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.

xLog address: [yjl9903](https://blog.onekuma.cn/)

Discord: XLor#0078
