### PR TITLE
feat: support checking if inside the app container.

### DIFF
--- a/src/app/api/redirection/route.ts
+++ b/src/app/api/redirection/route.ts
@@ -1,7 +1,7 @@
 import type { NoteEntity } from "crossbell"
 import { redirect } from "next/navigation"
 
-import { IS_VERCEL_PREVIEW } from "~/lib/constants"
+import { IS_DEV, IS_VERCEL_PREVIEW } from "~/lib/constants"
 import { getNoteSlug, getSiteLink } from "~/lib/helpers"
 import { NextServerResponse, getQuery } from "~/lib/server-helper"
 import { checkDomainServer } from "~/models/site.model"
@@ -94,7 +94,7 @@ export async function GET(req: Request): Promise<Response> {
     }
   }
 
-  if (IS_VERCEL_PREVIEW) {
+  if (IS_VERCEL_PREVIEW || IS_DEV) {
     const path = new URL(link).pathname
 
     redirect(`/site/${character.handle}${path}`)

--- a/src/app/site/[site]/[slug]/page.tsx
+++ b/src/app/site/[site]/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { PostFooter } from "~/components/site/PostFooter"
 import PostMeta from "~/components/site/PostMeta"
 import { SITE_URL } from "~/lib/env"
 import { getSiteLink } from "~/lib/helpers"
+import { isInRN } from "~/lib/is-in-rn"
 import getQueryClient from "~/lib/query-client"
 import { isOnlyContent } from "~/lib/search-parser"
 import { fetchGetPage } from "~/queries/page.server"
@@ -78,6 +79,8 @@ export default async function SitePagePage({
   }
 }) {
   const queryClient = getQueryClient()
+
+  const { inRN } = isInRN()
 
   const site = await fetchGetSite(params.site, queryClient)
 
@@ -156,7 +159,10 @@ export default async function SitePagePage({
           site={site}
           withActions={true}
         />
-        <OIAButton link={`/notes/${page?.noteId}/${page?.characterId}`} />
+        <OIAButton
+          isInRN={!!inRN}
+          link={`/notes/${page?.noteId}/${page?.characterId}`}
+        />
       </article>
       {!onlyContent && (
         <Hydrate state={dehydratedState}>

--- a/src/components/site/OIAButton.tsx
+++ b/src/components/site/OIAButton.tsx
@@ -7,8 +7,9 @@ import { useTranslation } from "~/lib/i18n/client"
 
 export const OIAButton: React.FC<{
   link: `/${string}`
-}> = ({ link }) => {
-  const { t, i18n } = useTranslation("site")
+  isInRN: boolean
+}> = ({ link, isInRN }) => {
+  const { t } = useTranslation("site")
   const [isVisible, setIsVisible] = useState(true)
 
   const oia = useCallback(() => {
@@ -32,7 +33,7 @@ export const OIAButton: React.FC<{
     return () => window.removeEventListener("scroll", handleScroll)
   }, [isMobileLayout])
 
-  if (!isMobileLayout) {
+  if (!isMobileLayout || isInRN) {
     return null
   }
 

--- a/src/lib/is-in-rn.ts
+++ b/src/lib/is-in-rn.ts
@@ -1,0 +1,23 @@
+import { headers } from "next/headers"
+import { userAgent } from "next/server"
+
+export function isInRN() {
+  const ua = userAgent({ headers: headers() }).ua
+
+  if (!ua)
+    return {
+      inRN: false,
+    }
+
+  const match = ua.match(/ReactNative\/(\d+\.\d+\.\d+)/)
+
+  if (!match)
+    return {
+      inRN: false,
+    }
+
+  return {
+    inRN: true,
+    version: match[1],
+  }
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d6f3e48</samp>

Added support for React Native users by hiding `OIAButton` component and improving redirection logic. Created a new `isInRN` function to detect the environment and used it in `page.tsx` and `OIAButton.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d6f3e48</samp>

> _`isInRN` checks_
> _user agent for React Native_
> _hides `OIAButton`_

### WHY
1. We should use the localhost URI to review the code changes.
```
  if (IS_VERCEL_PREVIEW || IS_DEV) {
    const path = new URL(link).pathname

    redirect(`/site/${character.handle}${path}`)
  } else {
    redirect(link)
  }
```
2. We can use `isInRN` method to do something for various platforms or versions.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d6f3e48</samp>

*  Import and use `IS_DEV` constant to improve redirection logic for preview and development environments ([link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-f633ff10f0971920cfba218909eacf62e478ef6b81ccd69ad3a97d4589ff74c2L4-R4), [link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-f633ff10f0971920cfba218909eacf62e478ef6b81ccd69ad3a97d4589ff74c2L97-R97))
*  Import and use `isInRN` function to detect and handle React Native users in page component ([link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-81b6f6a35cbf3df1600ee46e2cb30e93f659c85f1cf33846c5f4ffad391323d3R13), [link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-81b6f6a35cbf3df1600ee46e2cb30e93f659c85f1cf33846c5f4ffad391323d3R83-R84), [link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-81b6f6a35cbf3df1600ee46e2cb30e93f659c85f1cf33846c5f4ffad391323d3L159-R165))
*  Add `isInRN` prop to `OIAButton` component and conditionally render it based on the prop value ([link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-1ec1227c3a6248fade69524918bcc92cd819097a8aaa7c5a74719cdc1ca28a8dL10-R12), [link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-1ec1227c3a6248fade69524918bcc92cd819097a8aaa7c5a74719cdc1ca28a8dL35-R36))
*  Create `isInRN` function in `~/lib/is-in-rn` to check the user agent of the request and return an object with `inRN` and `version` properties ([link](https://github.com/Crossbell-Box/xLog/pull/598/files?diff=unified&w=0#diff-720522df533011c4e835e287c6ed32f9c79b284edee3c49407429536dc81371eR1-R23))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
