### PR TITLE
fix: scroll to anchor when init url with anchor

### DIFF
--- a/src/components/common/PageContent.tsx
+++ b/src/components/common/PageContent.tsx
@@ -5,6 +5,7 @@ import { MutableRefObject, useEffect, useMemo } from "react"
 import { PostActions } from "~/components/site/PostActions"
 import { PostToc } from "~/components/site/PostToc"
 import { useCodeCopy } from "~/hooks/useCodeCopy"
+import { useHash } from "~/hooks/useHash"
 import { ExpandedCharacter, ExpandedNote } from "~/lib/types"
 import { calculateElementTop, cn } from "~/lib/utils"
 import { renderPageContent } from "~/markdown"
@@ -34,6 +35,7 @@ export const PageContent: React.FC<{
   site,
   withActions,
 }) => {
+  const hash = useHash()
   useCodeCopy()
 
   const inParsedContent = useMemo(() => {
@@ -48,30 +50,22 @@ export const PageContent: React.FC<{
   }, [content, isComment, parsedContent])
 
   useEffect(() => {
-    const hashChangeHandler = () => {
-      const hash = decodeURIComponent(location.hash.slice(1))
-      if (hash) {
-        if (history.state?.preventScrollToToc) {
-          history.state.preventScrollToToc = false
-          return
-        }
-        const targetElement = document.querySelector(
-          `#user-content-${decodeURIComponent(hash)}`,
-        ) as HTMLElement
-        if (!targetElement) return
-
-        window.scrollTo({
-          top: calculateElementTop(targetElement) - 20,
-          behavior: "smooth",
-        })
-      }
+    const _hash = decodeURIComponent(hash.slice(1))
+    if (!_hash) return
+    if (history.state?.preventScrollToToc) {
+      history.state.preventScrollToToc = false
+      return
     }
+    const targetElement = document.querySelector(
+      `#user-content-${decodeURIComponent(_hash)}`,
+    ) as HTMLElement
+    if (!targetElement) return
 
-    window.addEventListener("hashchange", hashChangeHandler)
-    return () => {
-      window.removeEventListener("hashchange", hashChangeHandler)
-    }
-  }, [])
+    window.scrollTo({
+      top: calculateElementTop(targetElement) - 20,
+      behavior: "smooth",
+    })
+  }, [hash])
 
   return (
     <div

--- a/src/hooks/useHash.ts
+++ b/src/hooks/useHash.ts
@@ -1,0 +1,22 @@
+import { useCallback, useEffect, useState } from "react"
+
+export function useHash() {
+  const [hash, setHash] = useState("")
+
+  const onHashChange = useCallback(() => {
+    setHash(window.location.hash)
+  }, [])
+
+  useEffect(() => {
+    setHash(window.location.hash)
+  }, [])
+
+  useEffect(() => {
+    window.addEventListener("hashchange", onHashChange)
+    return () => {
+      window.removeEventListener("hashchange", onHashChange)
+    }
+  })
+
+  return hash
+}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b960e3b</samp>

The pull request adds a `useHash` custom hook to `src/hooks/useHash.ts` and uses it to improve the scroll effect of the `PageContent` component in `src/components/common/PageContent.tsx`. The custom hook simplifies the logic of getting and updating the window location hash and can be reused in other components.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b960e3b</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A clever `useHash` hook, to capture and update_
> _The window's changing location, with state and effects_
> _And made the `PageContent` scroll with grace and ease._

### WHY

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b960e3b</samp>

* Create and import a custom hook `useHash` to get and update the hash value of the window location ([link](https://github.com/Crossbell-Box/xLog/pull/599/files?diff=unified&w=0#diff-ef5952bd0a8831468a59208145e83a180ea60bca816de130e2259ebc9e80da3bR1-R22), [link](https://github.com/Crossbell-Box/xLog/pull/599/files?diff=unified&w=0#diff-8f034aaad4c24ae6c1e85bd4dd3c799617d6e3d9a2e79581976add25876c5430R8))
* Declare and assign a variable `hash` to store the value of `useHash` inside the `PageContent` component ([link](https://github.com/Crossbell-Box/xLog/pull/599/files?diff=unified&w=0#diff-8f034aaad4c24ae6c1e85bd4dd3c799617d6e3d9a2e79581976add25876c5430R38))
* Refactor the `useEffect` hook inside the `PageContent` component to use the `hash` variable instead of accessing the `location.hash` directly and add `hash` as a dependency ([link](https://github.com/Crossbell-Box/xLog/pull/599/files?diff=unified&w=0#diff-8f034aaad4c24ae6c1e85bd4dd3c799617d6e3d9a2e79581976add25876c5430L51-R68))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
