### PR TITLE
fix: solved the rendering bug of content.

### DIFF
--- a/src/components/site/PostToc.tsx
+++ b/src/components/site/PostToc.tsx
@@ -119,7 +119,7 @@ function Items(props: ItemsProps) {
                   createElement(Items, {
                     items: child,
                     activeId,
-                    prefix: `${index + 1}.`,
+                    prefix: `${prefix}${index + 1}.`,
                   })}
               </span>
             )


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2455c4e</samp>

Improved the table of contents component for posts by adding nested numbering for subheadings. Modified the `prefix` prop of the `Items` component in `PostToc.tsx` to achieve this.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 2455c4e</samp>

> _`prefix` prop changed_
> _Nested numbering for posts_
> _Autumn leaves guide us_

### WHY
Before:

![](https://cdn.discordapp.com/attachments/1023737717789556818/1114204881356607528/image.png)

After:

![](https://cdn.discordapp.com/attachments/1023737717789556818/1114738954701377577/image.png)

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2455c4e</samp>

*  Modify the `prefix` prop of the `Items` component to include the parent prefix for nested numbering of subheadings ([link](https://github.com/Crossbell-Box/xLog/pull/602/files?diff=unified&w=0#diff-102618deb90e88f122ec45f54cdb0097526040dc30fc1a726767942581e7709bL122-R122))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
xlog：https://0xaxe.xlog.app/
discord：0xAxe#0269 
