### PR TITLE
feat: link to xfeed

### DIFF
--- a/src/components/site/SiteHeader.tsx
+++ b/src/components/site/SiteHeader.tsx
@@ -17,7 +17,7 @@ import { Image } from "~/components/ui/Image"
 import { Modal } from "~/components/ui/Modal"
 import { Tooltip } from "~/components/ui/Tooltip"
 import { useIsDark } from "~/hooks/useDarkMode"
-import { CSB_IO, CSB_SCAN, CSB_XCHAR } from "~/lib/env"
+import { CSB_SCAN, CSB_XCHAR, CSB_XFEED } from "~/lib/env"
 import { useTranslation } from "~/lib/i18n/client"
 import { cn } from "~/lib/utils"
 import { useGetSite } from "~/queries/site"
@@ -78,7 +78,7 @@ export const SiteHeader: React.FC<{
     {
       text: "View on xFeed",
       icon: <XFeedLogo className="w-full h-full" />,
-      url: `${CSB_IO}/@${site.data?.handle}`,
+      url: `${CSB_XFEED}/u/${site.data?.handle}`,
     },
     {
       text: "View on Hoot It",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -15,6 +15,8 @@ export const DISCORD_LINK = process.env.NEXT_PUBLIC_DISCORD_LINK
 export const GITHUB_LINK = process.env.NEXT_PUBLIC_GITHUB_LINK
 export const TWITTER_LINK = process.env.NEXT_PUBLIC_TWITTER_LINK
 export const CSB_IO = process.env.NEXT_PUBLIC_CSB_IO || "https://crossbell.io"
+export const CSB_XFEED =
+  process.env.NEXT_PUBLIC_CSB_XFEED || "https://xfeed.app"
 export const CSB_SCAN =
   process.env.NEXT_PUBLIC_CSB_SCAN || "https://scan.crossbell.io"
 export const CSB_XCHAR =

--- a/src/lib/url-composer.ts
+++ b/src/lib/url-composer.ts
@@ -1,6 +1,6 @@
 import { ConnectKitProviderProps } from "@crossbell/connect-kit"
 
-import { CSB_IO } from "~/lib/env"
+import { CSB_XFEED } from "~/lib/env"
 import { getNoteSlug, getSiteLink } from "~/lib/helpers"
 
 export const urlComposer: ConnectKitProviderProps["urlComposer"] = {
@@ -35,7 +35,7 @@ export const urlComposer: ConnectKitProviderProps["urlComposer"] = {
         }
       }
     } else {
-      return `${CSB_IO}/notes/${note.characterId}-${note.noteId}`
+      return `${CSB_XFEED}/notes/${note.characterId}-${note.noteId}`
     }
   },
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ca49927</samp>

The pull request updates the code to use the new xFeed platform for notes and sites instead of the old CSB.IO service. It renames and adds environment variables and modifies the URL generation logic in `src/components/site/SiteHeader.tsx`, `src/lib/url-composer.ts`, and `src/lib/env.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ca49927</samp>

> _Sing, O Muse, of the code review that changed the face of the web_
> _How the valiant developers renamed the `CSB_IO` variable_
> _And updated the URLs to match the new domain of xFeed_
> _The mighty platform that hosts the notes and sites of many a hero_

### WHY
xFeed is now using a separate domain

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ca49927</samp>

*  Update the environment variable and URL for the xFeed platform ([link](https://github.com/Crossbell-Box/xLog/pull/606/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL20-R20), [link](https://github.com/Crossbell-Box/xLog/pull/606/files?diff=unified&w=0#diff-6e18f36f987fcb1f6f7ccb4a8218939f8069f905afdcb15ee50162c64582674dL81-R81), [link](https://github.com/Crossbell-Box/xLog/pull/606/files?diff=unified&w=0#diff-48fc28ac09c5305215c9178154a6caf8eedb90e42e44183606e9f2ad20311e46R18-R19), [link](https://github.com/Crossbell-Box/xLog/pull/606/files?diff=unified&w=0#diff-ad6c2c42ea2eaab667e8d10ffb379728390959a43fed104266567dcd1843a30cL3-R3), [link](https://github.com/Crossbell-Box/xLog/pull/606/files?diff=unified&w=0#diff-ad6c2c42ea2eaab667e8d10ffb379728390959a43fed104266567dcd1843a30cL38-R38))
