### PR TITLE
fix: replacing the download url.

### DIFF
--- a/src/app/oia/page.tsx
+++ b/src/app/oia/page.tsx
@@ -16,15 +16,9 @@ async function OIAPage() {
   }, [])
 
   const download = useCallback(() => {
-    const result = confirm(
-      t(
-        "The app is currently under review, please stay tuned. Do you want to join the early access program?",
-      )!,
+    window.open(
+      "https://apps.apple.com/us/app/xlog-on-chain-blogging/id6449499296",
     )
-    const dcLink = "https://discord.gg/uK2yAtWw2s"
-    if (result) {
-      window.open(dcLink)
-    }
   }, [])
 
   const goBack = useCallback(() => {

--- a/src/lib/i18n/locales/ja/site.json
+++ b/src/lib/i18n/locales/ja/site.json
@@ -8,7 +8,6 @@
   "Download": "ダウンロード",
   "Cancel Download": "ダウンロードをキャンセル",
   "Pull down to open the app": "ダウンロード済みですか？アプリを開くために引き下げてく",
-  "The app is currently under review, please stay tuned. Do you want to join the early access program?": "アプリは現在レビュー中です。お待ちください。アーリーアクセスプログラムに参加しますか？",
   "Write a comment on the blockchain": "ブロックチェーンでコメントする",
   "Open in App": "アプリで開く",
   "powered by": "<span>このサイトは　</span><name/><span> によって作動します</span>"

--- a/src/lib/i18n/locales/zh-TW/site.json
+++ b/src/lib/i18n/locales/zh-TW/site.json
@@ -19,7 +19,6 @@
   "Download": "立即下載",
   "Cancel Download": "取消下載",
   "Pull down to open the app": "已下載？下拉開啟應用程式",
-  "The app is currently under review, please stay tuned. Do you want to join the early access program?": "應用程式目前正在審核中，請靜候佳音。您想參加早期體驗計劃嗎？",
   "Back to Home": "回到首頁",
   "All Posts": "所有文章",
   "Open in App": "在 App 中開啟",

--- a/src/lib/i18n/locales/zh/site.json
+++ b/src/lib/i18n/locales/zh/site.json
@@ -20,7 +20,6 @@
   "Download": "立即下载",
   "Cancel Download": "取消下载",
   "Pull down to open the app": "已下载？下拉打开应用",
-  "The app is currently under review, please stay tuned. Do you want to join the early access program?": "应用正在审核中，敬请期待。是否加入内测计划？",
   "Back to Home": "返回主页",
   "All Posts": "所有文章",
   "Open in App": "在 App 中打开",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b0982d6</samp>

Simplify the download function in the `OIAPage` component to directly open the App Store link for the xLog app. Remove the unused confirmation dialog message translations from the `site.json` files.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b0982d6</samp>

> _`download` function_
> _simplified for xLog app_
> _no more dialog_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b0982d6</samp>

*  Simplified the `download` function in the `OIAPage` component to directly open the App Store link for the xLog app ([link](https://github.com/Crossbell-Box/xLog/pull/622/files?diff=unified&w=0#diff-3beeff222c0a9b5517fa83675052014be95de428a12243b2a8949fe3d2166625L19-R21))
* Removed the unused confirmation dialog message from the Japanese, Traditional Chinese, and Simplified Chinese translation files ([link](https://github.com/Crossbell-Box/xLog/pull/622/files?diff=unified&w=0#diff-6f370bd51a63c05759d8e4f54c38ec3861a16fd57e1494f2300fdef1bca9ced4L11), [link](https://github.com/Crossbell-Box/xLog/pull/622/files?diff=unified&w=0#diff-ffc95b9a7de7587a295e86794f7b6d30aeb7218982d00a6d19a7201e5ef00b6bL22), [link](https://github.com/Crossbell-Box/xLog/pull/622/files?diff=unified&w=0#diff-b1a526b7a0860b2f49f3d260cc370dba30445247771a09667eea284a1abc8542L23))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
