### PR TITLE
fix: Navigate to App Store directly.

### DIFF
--- a/src/app/oia/page.tsx
+++ b/src/app/oia/page.tsx
@@ -17,7 +17,7 @@ async function OIAPage() {
 
   const download = useCallback(() => {
     window.open(
-      "https://apps.apple.com/us/app/xlog-on-chain-blogging/id6449499296",
+      "itms-apps://apps.apple.com/app/xlog-on-chain-blogging/id6449499296",
     )
   }, [])
 


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b264ef2</samp>

Fix iOS app launch issues by using `itms-apps` scheme for App Store link in `page.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b264ef2</samp>

> _`download` function_
> _uses itms-apps scheme now_
> _no more Safari_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b264ef2</samp>

* Use the `itms-apps` scheme to open the App Store link directly from the iOS app ([link](https://github.com/Crossbell-Box/xLog/pull/623/files?diff=unified&w=0#diff-3beeff222c0a9b5517fa83675052014be95de428a12243b2a8949fe3d2166625L20-R20))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
