### PR TITLE
Add some basic key bindings for Markdown syntax

### DIFF
--- a/src/app/dashboard/[subdomain]/editor/page.tsx
+++ b/src/app/dashboard/[subdomain]/editor/page.tsx
@@ -34,7 +34,7 @@ import { Modal } from "~/components/ui/Modal"
 import { Switch } from "~/components/ui/Switch"
 import { TagInput } from "~/components/ui/TagInput"
 import { UniLink } from "~/components/ui/UniLink"
-import { toolbars } from "~/editor"
+import { toolbarShortcuts, toolbars } from "~/editor"
 import { editorUpload } from "~/editor/Multimedia"
 import {
   Values,
@@ -619,6 +619,7 @@ export default function SubdomainEditor() {
                         "h-full flex-1",
                         isRendering ? "border-r" : "",
                       )}
+                      shortcuts={toolbarShortcuts}
                     />
                   )}
                   {!isMobileLayout && (

--- a/src/components/ui/CodeMirror.tsx
+++ b/src/components/ui/CodeMirror.tsx
@@ -47,6 +47,7 @@ interface XLogCodeMirrorEditorProps {
   onCreateEditor?: (view: EditorView, state: EditorState) => void
   onMouseEnter?: () => void
   LoadingComponent?: () => JSX.Element
+  shortcuts?: KeyBinding[]
 }
 
 export const CodeMirrorEditor = forwardRef<
@@ -189,6 +190,7 @@ const LazyCodeMirrorEditor = forwardRef<
           }),
 
           keymap.of([
+            ...(props.shortcuts ?? []),
             ...defaultKeymap,
             ...historyKeymap,
             ...markdownKeymap,

--- a/src/editor/Bold.tsx
+++ b/src/editor/Bold.tsx
@@ -1,10 +1,23 @@
-import { ICommand, wrapExecute } from "."
+import { type EditorView } from "@codemirror/view"
+
+import { type ICommand, wrapExecute } from "."
+
+const action = (view: EditorView) => {
+  wrapExecute({ view, prepend: "**", append: "**" })
+}
 
 export const Bold: ICommand = {
   name: "bold",
   label: "Bold",
   icon: "icon-[mingcute--bold-line]",
-  execute: ({ view }) => {
-    wrapExecute({ view, prepend: "**", append: "**" })
+  execute({ view }) {
+    action(view)
+  },
+  shortcut: {
+    key: "Mod-b",
+    run(view) {
+      action(view)
+      return true
+    },
   },
 }

--- a/src/editor/Italic.tsx
+++ b/src/editor/Italic.tsx
@@ -1,10 +1,23 @@
-import { ICommand, wrapExecute } from "."
+import { type EditorView } from "@codemirror/view"
+
+import { type ICommand, wrapExecute } from "."
+
+const action = (view: EditorView) => {
+  wrapExecute({ view, prepend: "_", append: "_" })
+}
 
 export const Italic: ICommand = {
   name: "italic",
   label: "Italic",
   icon: "icon-[mingcute--italic-line]",
-  execute: ({ view }) => {
-    wrapExecute({ view, prepend: "_", append: "_" })
+  execute({ view }) {
+    action(view)
+  },
+  shortcut: {
+    key: "Mod-i",
+    run(view) {
+      action(view)
+      return true
+    },
   },
 }

--- a/src/editor/Link.tsx
+++ b/src/editor/Link.tsx
@@ -1,10 +1,23 @@
-import { ICommand, wrapExecute } from "."
+import { type EditorView } from "@codemirror/view"
+
+import { type ICommand, wrapExecute } from "."
+
+const action = (view: EditorView) => {
+  wrapExecute({ view, prepend: "[", append: "]()" })
+}
 
 export const Link: ICommand = {
   name: "link",
   label: "Link",
   icon: "icon-[mingcute--link-2-line]",
-  execute: ({ view }) => {
-    wrapExecute({ view, prepend: "[", append: "]()" })
+  execute({ view }) {
+    action(view)
+  },
+  shortcut: {
+    key: "Mod-k",
+    run(view) {
+      action(view)
+      return true
+    },
   },
 }

--- a/src/editor/Underline.tsx
+++ b/src/editor/Underline.tsx
@@ -1,10 +1,23 @@
-import { ICommand, wrapExecute } from "."
+import { type EditorView } from "@codemirror/view"
+
+import { type ICommand, wrapExecute } from "."
+
+const action = (view: EditorView) => {
+  wrapExecute({ view, prepend: "<u>", append: "</u>" })
+}
 
 export const Underline: ICommand = {
   name: "underline",
   label: "Underline",
   icon: "icon-[mingcute--underline-line]",
   execute: ({ view }) => {
-    wrapExecute({ view, prepend: "<u>", append: "</u>" })
+    action(view)
+  },
+  shortcut: {
+    key: "Mod-u",
+    run(view) {
+      action(view)
+      return true
+    },
   },
 }

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from "react"
 
 import { EditorSelection } from "@codemirror/state"
-import { EditorView } from "@codemirror/view"
+import { type EditorView, type KeyBinding } from "@codemirror/view"
 
 import { AlignCenter } from "./AlignCenter"
 import { AlignRight } from "./AlignRight"
@@ -42,6 +42,8 @@ export type ICommand<P = any> = {
     transferPayload: (payload: P) => void
     view: EditorView
   }) => JSX.Element
+
+  shortcut?: KeyBinding
 }
 
 export type IPrependExecute = {
@@ -105,6 +107,10 @@ export const toolbars: ICommand[] = [
   Cloud,
   Help,
 ]
+
+export const toolbarShortcuts = toolbars
+  .map((t) => t.shortcut)
+  .filter(<T,>(v: T): v is NonNullable<T> => !!v)
 
 export { wrapExecute } from "./helper"
 export type { IWrapExecute } from "./helper"


### PR DESCRIPTION
Bold: `cmd + b`
Italic: `cmd + i`
Underline: `cmd + u`
Link: `cmd + k`

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 845c59b</samp>

This pull request adds keyboard shortcuts for common editor commands in the xLog application. It modifies the `XLogCodeMirrorEditor` component and the command modules in `src/editor` to support the `shortcuts` prop and the `keymap` prop of the `EditorView` component. It also enhances the editor component in `src/app/dashboard/[subdomain]/editor/page.tsx` with the `toolbarShortcuts` variable.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 845c59b</samp>

> _We are the masters of the editor_
> _We wield the power of the `shortcut`_
> _We wrap the text with symbols of doom_
> _We make the words obey our command_

### WHY

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 845c59b</samp>

*  Add keyboard shortcuts for editor commands ([link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-37b78c444c95ad2fc34b5a3632c3f72686c75f24a3a1d5876872d5d0cc08d261L37-R37), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-37b78c444c95ad2fc34b5a3632c3f72686c75f24a3a1d5876872d5d0cc08d261R622), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-abea3d6f52ccf12e87503b823db64594df934a280129d99326a69b9794cfe0a9R50), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-abea3d6f52ccf12e87503b823db64594df934a280129d99326a69b9794cfe0a9R193), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-794f034211378eaf3a1cba96dac0d41be1988fe388b9f481258abac287e46d9eL1-R22), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-6b5a0434fedcdd277e64143b322b2d7f7191d5d3a1cac5acc339717854c547ddL1-R22), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-ec2f2827b3d052ac7c7b924838664b1fbad802c08c8fe5930d098f94da73da33L1-R22), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-ab4ee561a237dce64fde5108aebaeed1664bed5ec5f5d63be1d70036601073dcL1-R8), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-ab4ee561a237dce64fde5108aebaeed1664bed5ec5f5d63be1d70036601073dcL8-R22), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eL4-R4), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR45-R46), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR111-R114))
  * Import the `toolbarShortcuts` variable from the `~/editor` module in `src/app/dashboard/[subdomain]/editor/page.tsx` and pass it as a prop to the `LazyCodeMirrorEditor` component ([link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-37b78c444c95ad2fc34b5a3632c3f72686c75f24a3a1d5876872d5d0cc08d261L37-R37), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-37b78c444c95ad2fc34b5a3632c3f72686c75f24a3a1d5876872d5d0cc08d261R622))
  * Add the `shortcuts` prop to the `XLogCodeMirrorEditorProps` interface and spread it into the `keymap` prop of the `EditorView` component in `src/components/ui/CodeMirror.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-abea3d6f52ccf12e87503b823db64594df934a280129d99326a69b9794cfe0a9R50), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-abea3d6f52ccf12e87503b823db64594df934a280129d99326a69b9794cfe0a9R193))
  * Extract the actions of wrapping the selected text with formatting symbols or tags into separate functions and add the `shortcut` property to the command objects in `src/editor/Bold.tsx`, `src/editor/Italic.tsx`, `src/editor/Link.tsx`, and `src/editor/Underline.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-794f034211378eaf3a1cba96dac0d41be1988fe388b9f481258abac287e46d9eL1-R22), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-6b5a0434fedcdd277e64143b322b2d7f7191d5d3a1cac5acc339717854c547ddL1-R22), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-ec2f2827b3d052ac7c7b924838664b1fbad802c08c8fe5930d098f94da73da33L1-R22), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-ab4ee561a237dce64fde5108aebaeed1664bed5ec5f5d63be1d70036601073dcL1-R8), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-ab4ee561a237dce64fde5108aebaeed1664bed5ec5f5d63be1d70036601073dcL8-R22))
  * Import the types for the editor view component and the keyboard shortcut object and add the `shortcut` property to the `ICommand` interface in `src/editor/index.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eL4-R4), [link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR45-R46))
  * Define the `toolbarShortcuts` variable as an array of keyboard shortcuts for the editor commands by mapping and filtering the `shortcut` property of each command in the `toolbars` array in `src/editor/index.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/628/files?diff=unified&w=0#diff-7ee6c0a2f0093f8c1f315c4be6d17d4ba350b4de2b9634a73d43db4bd67d939eR111-R114))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
