### PR TITLE
feat(editor): display autocomplete suggestions when mentioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@birdgg/react-github": "0.2.3",
+    "@codemirror/autocomplete": "^6.8.0",
     "@codemirror/commands": "6.2.4",
     "@codemirror/lang-markdown": "6.1.1",
     "@codemirror/language": "6.8.0",
@@ -44,6 +45,7 @@
     "@crossbell/notification": "1.4.0",
     "@crossbell/ui": "1.4.0",
     "@crossbell/util-hooks": "1.4.0",
+    "@crossbell/util-metadata": "^1.4.0",
     "@ddietr/codemirror-themes": "1.4.1",
     "@dqbd/tiktoken": "1.0.7",
     "@emoji-mart/data": "1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   '@birdgg/react-github':
     specifier: 0.2.3
     version: 0.2.3(react-dom@18.2.0)(react@18.2.0)
+  '@codemirror/autocomplete':
+    specifier: ^6.8.0
+    version: 6.8.0(@codemirror/language@6.8.0)(@codemirror/state@6.2.1)(@codemirror/view@6.13.2)(@lezer/common@1.0.3)
   '@codemirror/commands':
     specifier: 6.2.4
     version: 6.2.4
@@ -47,6 +50,9 @@ dependencies:
   '@crossbell/util-hooks':
     specifier: 1.4.0
     version: 1.4.0(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(zod@3.21.4)
+  '@crossbell/util-metadata':
+    specifier: ^1.4.0
+    version: 1.4.0(typescript@5.1.3)(zod@3.21.4)
   '@ddietr/codemirror-themes':
     specifier: 1.4.1
     version: 1.4.1

--- a/src/components/ui/CodeMirror.tsx
+++ b/src/components/ui/CodeMirror.tsx
@@ -16,6 +16,7 @@ import { Annotation } from "@codemirror/state"
 import { EditorView, KeyBinding, ViewUpdate } from "@codemirror/view"
 import { tags } from "@lezer/highlight"
 
+import { mentionAutocompletion } from "~/editor/mention-autocompletion"
 import {
   monospaceFonts,
   useCodeMirrorAutoToggleTheme,
@@ -231,6 +232,7 @@ const LazyCodeMirrorEditor = forwardRef<
             },
           }),
           EditorView.lineWrapping,
+          mentionAutocompletion(),
         ],
       })
 

--- a/src/editor/mention-autocompletion.tsx
+++ b/src/editor/mention-autocompletion.tsx
@@ -1,0 +1,70 @@
+import { type CharacterEntity } from "crossbell"
+
+import { type Completion, autocompletion } from "@codemirror/autocomplete"
+import { indexer } from "@crossbell/indexer"
+import { getDefaultAvatarIpfsUrl } from "@crossbell/ui"
+import {
+  extractCharacterAvatar,
+  extractCharacterName,
+} from "@crossbell/util-metadata"
+
+import { toGateway } from "~/lib/ipfs-parser"
+
+async function fetchCharacters(query: string) {
+  return (await indexer.search.characters(query, { limit: 10 })).list
+}
+
+type CompletionWithCharacter = Completion & { character?: CharacterEntity }
+
+export function mentionAutocompletion() {
+  return autocompletion({
+    icons: false,
+    addToOptions: [
+      {
+        render({ character }: CompletionWithCharacter) {
+          if (!character) return null
+
+          const container = document.createElement("div")
+          const img = document.createElement("img")
+
+          container.className =
+            "inline-flex items-center justify-center pr-1 py-1 align-middle"
+          img.className = "w-5 h-5 object-cover rounded-md"
+          img.src = toGateway(
+            extractCharacterAvatar(character) ??
+              getDefaultAvatarIpfsUrl(character.handle),
+          )
+
+          container.appendChild(img)
+
+          return container
+        },
+        position: 20,
+      },
+    ],
+    override: [
+      async (context) => {
+        let word = context.matchBefore(/@\w+/)
+
+        if (!word) return null
+
+        const characters = await fetchCharacters(word.text.slice(1))
+        const completions: Completion[] = characters.map((character) => {
+          const handle = `@${character.handle}`
+          const characterName = extractCharacterName(character, {
+            fallbackToHandle: false,
+          })
+
+          return {
+            label: handle,
+            detail: characterName,
+            apply: `${handle} `,
+            character,
+          }
+        })
+
+        return { from: word.from, options: completions }
+      },
+    ],
+  })
+}


### PR DESCRIPTION


https://github.com/Crossbell-Box/xLog/assets/12002941/bf792c5f-4b0c-4f64-b799-e280b9369bb6


### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b10d1c2</samp>

This pull request adds a feature that allows users to mention Crossbell characters in the CodeMirror editor by typing `@` followed by the character name. It uses two new packages, `@codemirror/autocomplete` and `@crossbell/util-metadata`, to implement a custom autocompletion plugin that fetches and displays character data. It also modifies some CSS files to style the completion items.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at b10d1c2</samp>

> _Oh, we're the merry coders of the Crossbell crew_
> _We write and edit entities with `CodeMirror` too_
> _We fetch and show the characters with `mentionAutocompletion`_
> _And hoist the sail with metadata on the count of three_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b10d1c2</samp>

*  Add `@codemirror/autocomplete` and `@crossbell/util-metadata` packages as dependencies to enable character mention autocompletion in the editor ([link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R34), [link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R48), [link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11-R13), [link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR53-R55))
* Import and apply the custom `mentionAutocompletion` plugin to the `LazyCodeMirrorEditor` component in `src/components/ui/CodeMirror.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-abea3d6f52ccf12e87503b823db64594df934a280129d99326a69b9794cfe0a9R19), [link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-abea3d6f52ccf12e87503b823db64594df934a280129d99326a69b9794cfe0a9R235))
* Define the `mentionAutocompletion` function in `src/editor/mention-autocompletion.tsx`, using the imported packages to fetch and display character data ([link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-5a88907fadbe3e2f04c3033b2db39eab173c1003c8af300c13674c3f6fd1c2f0R1-R70))
* Hide the default completion icon for the `hidden` type of completion, which is used for character mentions, in `src/css/codemirror.css` ([link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-af8542494f3dde2d95fc803e17e2c45dd3d7617b5c0c6bbbfaf17320b2e319c7R1-R3))
* Import the `codemirror.css` file to the main stylesheet `src/css/main.css` ([link](https://github.com/Crossbell-Box/xLog/pull/635/files?diff=unified&w=0#diff-36ebfd7bbcd72a8d3e81092b646f4c4427ad2496c2bc1d428c7b5e0ba29430f9R9))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
