### PR TITLE
chore: tweak future release notice color

### DIFF
--- a/src/app/dashboard/[subdomain]/editor/page.tsx
+++ b/src/app/dashboard/[subdomain]/editor/page.tsx
@@ -799,7 +799,7 @@ const EditorExtraProperties = memo(
           {values.publishedAt > new Date().toISOString() && (
             <div className="text-xs mt-1 text-green-600">
               {t(
-                "The post is currently unavailable as its publication date has been scheduled for a future time.",
+                "The post is currently not public as its publication date has been scheduled for a future time.",
               )}
             </div>
           )}

--- a/src/app/dashboard/[subdomain]/editor/page.tsx
+++ b/src/app/dashboard/[subdomain]/editor/page.tsx
@@ -797,7 +797,7 @@ const EditorExtraProperties = memo(
             )}
           </div>
           {values.publishedAt > new Date().toISOString() && (
-            <div className="text-xs mt-1 text-green-600">
+            <div className="text-xs mt-1 text-orange-500">
               {t(
                 "The post is currently not public as its publication date has been scheduled for a future time.",
               )}

--- a/src/app/dashboard/[subdomain]/editor/page.tsx
+++ b/src/app/dashboard/[subdomain]/editor/page.tsx
@@ -797,7 +797,7 @@ const EditorExtraProperties = memo(
             )}
           </div>
           {values.publishedAt > new Date().toISOString() && (
-            <div className="text-xs mt-1 text-red-500">
+            <div className="text-xs mt-1 text-green-600">
               {t(
                 "The post is currently unavailable as its publication date has been scheduled for a future time.",
               )}

--- a/src/lib/i18n/locales/ja/dashboard.json
+++ b/src/lib/i18n/locales/ja/dashboard.json
@@ -64,7 +64,7 @@
   "Publish at": "公開日時",
   "This post will be accessible from this time. Leave blank to use the current time.": "この記事は以下の日時からアクセス可能になります。現在の日時を使用する場合は空白のままにしてください。",
   "This page will be accessible from this time. Leave blank to use the current time.": "このページは以下の日時からアクセス可能になります。現在の日時を使用する場合は空白のままにしてください。",
-  "The post is currently unavailable as its publication date has been scheduled for a future time.": "この記事は現在利用できません。公開日時が未来に設定されています。",
+  "The post is currently not public as its publication date has been scheduled for a future time.": "この記事は現在非公開です。公開日時が未来に設定されています。",
   "Post slug": "記事スラッグ",
   "Page slug": "ページスラッグ",
   "This post will be accessible at": "この記事は以下のリンクからアクセス可能になります",

--- a/src/lib/i18n/locales/zh-TW/dashboard.json
+++ b/src/lib/i18n/locales/zh-TW/dashboard.json
@@ -68,7 +68,7 @@
     "Publish at": "發布時間",
     "This post will be accessible from this time. Leave blank to use the current time.": "文章將在此時間後可訪問。留空則使用當前時間。",
     "This page will be accessible from this time. Leave blank to use the current time.": "頁面將在此時間後可訪問。留空則使用當前時間。",
-    "The post is currently unavailable as its publication date has been scheduled for a future time.": "該帖子目前無法使用，因為它的發布日期已被安排在未來。",
+    "The post is currently not public as its publication date has been scheduled for a future time.": "該帖子目前沒有公開，因為它的發布日期已被安排在未來。",
     "Post slug": "文章短連結",
     "Page slug": "頁面短連結",
     "This post will be accessible at": "此文章將可通過以下連結瀏覽",

--- a/src/lib/i18n/locales/zh/dashboard.json
+++ b/src/lib/i18n/locales/zh/dashboard.json
@@ -70,7 +70,7 @@
   "Publish at": "发布时间",
   "This post will be accessible from this time. Leave blank to use the current time.": "此文章将从此时间开始可访问。留空则使用当前时间。",
   "This page will be accessible from this time. Leave blank to use the current time.": "此页面将从此时间开始可访问。留空则使用当前时间。",
-  "The post is currently unavailable as its publication date has been scheduled for a future time.": "此文章当前不可用，因为它的发布日期已被定为将来的某个时间。",
+  "The post is currently not public as its publication date has been scheduled for a future time.": "此文章当前没有公开，因为它的发布日期已被定为将来的某个时间。",
   "Post slug": "文章短链接",
   "Page slug": "页面短链接",
   "This post will be accessible at": "此文章将可通过以下链接访问",


### PR DESCRIPTION
...to prevent misunderstanding

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cfc7e12</samp>

Changed the text color of the scheduled post message in the editor page to green. This improves the user experience and avoids confusion with error messages.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at cfc7e12</samp>

> _Scheduled post message_
> _`text-color` now is green_
> _Spring of no errors_

### WHY
https://discord.com/channels/976854077709369424/1023737717789556818/1118361059837886495

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at cfc7e12</samp>

* Changed the text color of the scheduled post message to green ([link](https://github.com/Crossbell-Box/xLog/pull/636/files?diff=unified&w=0#diff-37b78c444c95ad2fc34b5a3632c3f72686c75f24a3a1d5876872d5d0cc08d261L800-R800)) in `src/app/dashboard/[subdomain]/editor/page.tsx`. This improves the user experience by avoiding confusion with error messages and indicating that the scheduling is intentional.

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
