### PR TITLE
fix: optimize code and fix loading button style

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,5 +1,9 @@
 module.exports = {
-  extends: ["next/core-web-vitals", "plugin:import/recommended", "plugin:react/recommended"],
+  extends: [
+    "next/core-web-vitals",
+    "plugin:import/recommended",
+    "plugin:react/recommended",
+  ],
   root: true,
   settings: {
     "import/resolver": {
@@ -13,7 +17,8 @@ module.exports = {
     "import/no-anonymous-default-export": "off",
     "import/no-named-as-default": "off",
     "react/react-in-jsx-scope": "off",
-    "react-hooks/exhaustive-deps": "off",
+    "react-hooks/exhaustive-deps":
+      process.env.NODE_ENV === "production" ? "off" : "warn",
     "import/no-named-as-default-member": "off",
   },
 }

--- a/src/app/dashboard/[subdomain]/editor/page.tsx
+++ b/src/app/dashboard/[subdomain]/editor/page.tsx
@@ -43,7 +43,7 @@ import {
 } from "~/hooks/useEdtiorState"
 import { useGetState } from "~/hooks/useGetState"
 import { useIsMobileLayout } from "~/hooks/useMobileLayout"
-import { useSyncOnce } from "~/hooks/useSyncOnce"
+import { useBeforeMounted } from "~/hooks/useSyncOnce"
 import { useUploadFile } from "~/hooks/useUploadFile"
 import { showConfetti } from "~/lib/confetti"
 import { getDefaultSlug } from "~/lib/default-slug"
@@ -154,7 +154,7 @@ export default function SubdomainEditor() {
   const uploadFile = useUploadFile()
 
   // reset editor state when page changes
-  useSyncOnce(() => {
+  useBeforeMounted(() => {
     useEditorState.setState(initialEditorState)
   })
 

--- a/src/components/site/PostList.tsx
+++ b/src/components/site/PostList.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useEffect, useState } from "react"
+import { memo } from "react"
 import reactStringReplace from "react-string-replace"
 
 import { UseInfiniteQueryResult } from "@tanstack/react-query"
@@ -11,6 +11,7 @@ import FadeIn from "~/components/common/FadeIn"
 import PostCover from "~/components/site/PostCover"
 import { Button } from "~/components/ui/Button"
 import { EmptyState } from "~/components/ui/EmptyState"
+import { useIsClient } from "~/hooks/useClient"
 import { useDate } from "~/hooks/useDate"
 import { getSlugUrl } from "~/lib/helpers"
 import { useTranslation } from "~/lib/i18n/client"
@@ -30,16 +31,7 @@ export default function PostList({
   >
   keyword?: string
 }) {
-  const router = useRouter()
-
   const { t } = useTranslation("site")
-  const date = useDate()
-
-  const [isMounted, setIsMounted] = useState(false)
-
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
 
   if (!posts.data?.pages?.length) return null
 
@@ -54,91 +46,7 @@ export default function PostList({
             posts.list.map((post) => {
               currentLength++
               return (
-                <FadeIn
-                  key={`${post.characterId}-${post.noteId}`}
-                  className="xlog-post -mx-5 first:-mt-5 sm:rounded-2xl bg-white"
-                  role="article"
-                  aria-label={post.metadata?.content?.title}
-                >
-                  <Link
-                    className="flex flex-col sm:flex-row items-center group px-5 py-7 focus-visible:outline focus-visible:outline-accent"
-                    href={getSlugUrl(`/${post.metadata?.content?.slug}`)}
-                    suppressHydrationWarning
-                  >
-                    <PostCover cover={post.metadata?.content?.cover} />
-                    <div className="flex-1 flex justify-center flex-col w-full min-w-0">
-                      <h3 className="xlog-post-title text-2xl font-bold text-zinc-700 line-clamp-2">
-                        {post.metadata?.content?.title}
-                      </h3>
-                      <div className="xlog-post-meta text-sm text-zinc-400 mt-1 space-x-4 flex items-center mr-8">
-                        <time
-                          dateTime={date.formatToISO(
-                            post.metadata?.content?.date_published || "",
-                          )}
-                          className="xlog-post-date whitespace-nowrap"
-                        >
-                          {date.formatDate(
-                            post.metadata?.content?.date_published || "",
-                            undefined,
-                            isMounted ? undefined : "America/Los_Angeles",
-                          )}
-                        </time>
-                        {!!post.metadata?.content?.tags?.filter(
-                          (tag) => tag !== "post" && tag !== "page",
-                        ).length && (
-                          <span
-                            aria-label="tags for this post"
-                            className="xlog-post-tags space-x-1 truncate min-w-0"
-                          >
-                            {post.metadata?.content?.tags
-                              ?.filter(
-                                (tag) => tag !== "post" && tag !== "page",
-                              )
-                              .map((tag) => (
-                                <span
-                                  className="hover:text-zinc-600"
-                                  key={tag}
-                                  onClick={(e) => {
-                                    e.stopPropagation()
-                                    e.preventDefault()
-                                    router.push(`/tag/${tag}`)
-                                  }}
-                                >
-                                  #{tag}
-                                </span>
-                              ))}
-                          </span>
-                        )}
-                        <span
-                          aria-label="views for this post"
-                          className="xlog-post-views inline-flex items-center"
-                        >
-                          <i className="icon-[mingcute--eye-line] mr-[2px]" />
-                          <span>{post.metadata?.content?.views}</span>
-                        </span>
-                      </div>
-                      <div
-                        className="xlog-post-excerpt mt-3 text-zinc-500 line-clamp-2"
-                        style={{
-                          wordBreak: "break-word",
-                        }}
-                      >
-                        {keyword
-                          ? reactStringReplace(
-                              post.metadata?.content?.summary || "",
-                              keyword,
-                              (match, i) => (
-                                <span key={i} className="bg-yellow-200">
-                                  {match}
-                                </span>
-                              ),
-                            )
-                          : post.metadata?.content?.summary}
-                        {post.metadata?.content?.summary && "..."}
-                      </div>
-                    </div>
-                  </Link>
-                </FadeIn>
+                <PostItem post={post} keyword={keyword} key={post.noteId} />
               )
             }),
           )}
@@ -147,7 +55,7 @@ export default function PostList({
       {posts.hasNextPage && (
         <div className="text-center">
           <Button
-            className="mt-8 truncate max-w-full !inline-block"
+            className="mt-8 truncate max-w-full !inline-block before:!hidden"
             variant="outline"
             onClick={() => posts.fetchNextPage()}
             isLoading={posts.isFetchingNextPage}
@@ -167,3 +75,99 @@ export default function PostList({
     </>
   )
 }
+
+const PostItem = memo(
+  ({ post, keyword }: { post: ExpandedNote; keyword?: string }) => {
+    const isMounted = useIsClient()
+    const date = useDate()
+    const router = useRouter()
+
+    return (
+      <FadeIn
+        key={`${post.characterId}-${post.noteId}`}
+        className="xlog-post -mx-5 first:-mt-5 sm:rounded-2xl bg-white"
+        role="article"
+        aria-label={post.metadata?.content?.title}
+      >
+        <Link
+          className="flex flex-col sm:flex-row items-center group px-5 py-7 focus-visible:outline focus-visible:outline-accent"
+          href={getSlugUrl(`/${post.metadata?.content?.slug}`)}
+          suppressHydrationWarning
+        >
+          <PostCover cover={post.metadata?.content?.cover} />
+          <div className="flex-1 flex justify-center flex-col w-full min-w-0">
+            <h3 className="xlog-post-title text-2xl font-bold text-zinc-700 line-clamp-2">
+              {post.metadata?.content?.title}
+            </h3>
+            <div className="xlog-post-meta text-sm text-zinc-400 mt-1 space-x-4 flex items-center mr-8">
+              <time
+                dateTime={date.formatToISO(
+                  post.metadata?.content?.date_published || "",
+                )}
+                className="xlog-post-date whitespace-nowrap"
+              >
+                {date.formatDate(
+                  post.metadata?.content?.date_published || "",
+                  undefined,
+                  isMounted ? undefined : "America/Los_Angeles",
+                )}
+              </time>
+              {!!post.metadata?.content?.tags?.filter(
+                (tag) => tag !== "post" && tag !== "page",
+              ).length && (
+                <span
+                  aria-label="tags for this post"
+                  className="xlog-post-tags space-x-1 truncate min-w-0"
+                >
+                  {post.metadata?.content?.tags
+                    ?.filter((tag) => tag !== "post" && tag !== "page")
+                    .map((tag) => (
+                      <span
+                        className="hover:text-zinc-600"
+                        key={tag}
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          e.preventDefault()
+                          router.push(`/tag/${tag}`)
+                        }}
+                      >
+                        #{tag}
+                      </span>
+                    ))}
+                </span>
+              )}
+              <span
+                aria-label="views for this post"
+                className="xlog-post-views inline-flex items-center"
+              >
+                <i className="icon-[mingcute--eye-line] mr-[2px]" />
+                <span>{post.metadata?.content?.views}</span>
+              </span>
+            </div>
+            <div
+              className="xlog-post-excerpt mt-3 text-zinc-500 line-clamp-2"
+              style={{
+                wordBreak: "break-word",
+              }}
+            >
+              {keyword
+                ? reactStringReplace(
+                    post.metadata?.content?.summary || "",
+                    keyword,
+                    (match, i) => (
+                      <span key={i} className="bg-yellow-200">
+                        {match}
+                      </span>
+                    ),
+                  )
+                : post.metadata?.content?.summary}
+              {post.metadata?.content?.summary && "..."}
+            </div>
+          </div>
+        </Link>
+      </FadeIn>
+    )
+  },
+)
+
+PostItem.displayName = "PostItem"

--- a/src/hooks/useDarkMode.ts
+++ b/src/hooks/useDarkMode.ts
@@ -31,7 +31,7 @@ interface DarkModeConfig {
   classNameLight?: string // A className to set "light mode". Default = "light".
   element?: HTMLElement | undefined | null // The element to apply the className. Default = `document.body`.
   storageKey?: string // Specify the `localStorage` key. Default = "darkMode". set to `undefined` to disable persistent storage.
-  transition?: any // Specify the `animate` when switching the mode. Only Chromium >= 111 etc.
+  transition?: ViewTransition | undefined // Specify the `animate` when switching the mode. Only Chromium >= 111 etc.
 }
 
 const darkModeKey = "darkMode"
@@ -117,17 +117,17 @@ const useDarkModeInternal = (
     if (isServerSide() || typeof darkMode === "undefined") {
       return
     }
+    const $document = element || document.documentElement
     const setDarkModeClass = () => {
       if (darkMode) {
-        $el.classList.remove(classNameLight)
-        $el.classList.add(classNameDark)
+        $document.classList.remove(classNameLight)
+        $document.classList.add(classNameDark)
       } else {
-        $el.classList.remove(classNameDark)
-        $el.classList.add(classNameLight)
+        $document.classList.remove(classNameDark)
+        $document.classList.add(classNameLight)
       }
     }
 
-    const $el = element || document.documentElement
     const { x, y } = mousePosition
     const endRadius = Math.hypot(
       Math.max(x, innerWidth - x),
@@ -140,7 +140,7 @@ const useDarkModeInternal = (
         `circle(0px at ${x}px ${y}px)`,
         `circle(${endRadius}px at ${x}px ${y}px)`,
       ]
-      $el.animate(
+      $document.animate(
         {
           clipPath: !darkMode ? clipPath : [...clipPath].reverse(),
         },

--- a/src/hooks/useSyncOnce.ts
+++ b/src/hooks/useSyncOnce.ts
@@ -3,7 +3,7 @@ import { useRef } from "react"
 /**
  * @description `useSyncOnce` is a hook that will run a function once and only once, before the useEffect called, it means before `onMounted`.
  */
-export const useSyncOnce = (fn: () => any) => {
+export const useBeforeMounted = (fn: () => any) => {
   const onceRef = useRef(false)
   if (onceRef.current) return
   fn()

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -12,7 +12,15 @@ declare global {
 
   var prisma: PrismaClient | undefined
 
+  // TODO should remove in next TypeScript version
   interface Document {
-    startViewTransition(): void
+    startViewTransition(callback?: () => void | Promise<void>): ViewTransition
+  }
+
+  interface ViewTransition {
+    finished: Promise<void>
+    ready: Promise<void>
+    updateCallbackDone: () => void
+    skipTransition(): void
   }
 }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e04b853</samp>

This pull request updates the eslint configuration, renames some custom hooks, refactors the `PostList` component, and improves the type safety and readability of some hooks. The main purpose is to enhance the code quality, performance, and maintainability of the project.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e04b853</samp>

> _Some hooks and components were renamed_
> _To make the code clearer and tamed_
> _`useBeforeMounted` and `useDarkMode`_
> _Were among those that showed_
> _How the code quality was improved and claimed_

### WHY

Fix this button style. Remove this button `:before` when loading
<img width="381" alt="CleanShot 2023-06-14 at 10 01 17@2x" src="https://github.com/Crossbell-Box/xLog/assets/41265413/2912648b-ae6d-43b3-87f2-33e80af7c0c4">

And optimize some code.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e04b853</samp>

*  Rename `useSyncOnce` hook to `useBeforeMounted` for clarity and consistency ([link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-37b78c444c95ad2fc34b5a3632c3f72686c75f24a3a1d5876872d5d0cc08d261L46-R46), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-37b78c444c95ad2fc34b5a3632c3f72686c75f24a3a1d5876872d5d0cc08d261L157-R157), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-d6a15b8896cd8b749b24a7a9e4d9e1b17b54af55dcffe36cf15a19af021690baL6-R6))
*  Extract and memoize `PostItem` component from `PostList.tsx` for performance and readability ([link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-467c1f65027c82983a744027217105e04bb959b7e4f6fc7f8ec39bea24f9dbd6L5-R5), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-467c1f65027c82983a744027217105e04bb959b7e4f6fc7f8ec39bea24f9dbd6R14), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-467c1f65027c82983a744027217105e04bb959b7e4f6fc7f8ec39bea24f9dbd6L33-R35), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-467c1f65027c82983a744027217105e04bb959b7e4f6fc7f8ec39bea24f9dbd6L57-R49), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-467c1f65027c82983a744027217105e04bb959b7e4f6fc7f8ec39bea24f9dbd6L150-R58), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-467c1f65027c82983a744027217105e04bb959b7e4f6fc7f8ec39bea24f9dbd6R78-R173))
*  Modify `react-hooks/exhaustive-deps` rule in `.eslintrc.cjs` to warn only in development mode ([link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-e1ce717e1179a0db14e90ec5374768a206651ca807db58352991eb7895ed7c9cL16-R21))
*  Change `transition` property type in `DarkModeConfig` interface to `ViewTransition | undefined` in `useDarkMode.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L34-R34))
*  Rename `$el` variable to `$document` in `useDarkModeInternal` function in `useDarkMode.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L120-R130), [link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L143-R143))
*  Reformat `extends` property in `.eslintrc.cjs` for readability and consistency ([link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-e1ce717e1179a0db14e90ec5374768a206651ca807db58352991eb7895ed7c9cL2-R6))
*  Add `before:!hidden` class to `Button` component in `PostList.tsx` to hide icon on small screens ([link](https://github.com/Crossbell-Box/xLog/pull/637/files?diff=unified&w=0#diff-467c1f65027c82983a744027217105e04bb959b7e4f6fc7f8ec39bea24f9dbd6L150-R58))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
