### PR TITLE
style: remove titles in buttons of Toolbar

### DIFF
--- a/src/components/ui/EditorToolbar.tsx
+++ b/src/components/ui/EditorToolbar.tsx
@@ -59,7 +59,6 @@ const ToolbarItemWithPopover = ({
           >
             <Popover.Button
               key={name}
-              title={name}
               className="w-9 h-9 transition-colors text-lg border border-transparent rounded flex items-center justify-center text-zinc-500 group-hover:text-zinc-600 hover:text-zinc-500 hover:border-zinc-300 hover:bg-zinc-100"
               ref={setPopoverButtonRef}
             >


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9a41865</samp>

Removed `title` prop from `ToolbarItemWithPopover` component in `EditorToolbar.tsx` to eliminate redundant tooltips. Refactored editor toolbar UI for better usability and accessibility.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 9a41865</samp>

> _`title` prop is gone_
> _No more redundant tooltips_
> _Toolbar is clearer_

### WHY
<!-- author to complete -->
<img width="409" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/5175751/c06b9500-9935-4332-9f4c-e136e6ae98d1">

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 9a41865</samp>

* Remove `title` prop from `ToolbarItemWithPopover` component to avoid redundant tooltips ([link](https://github.com/Crossbell-Box/xLog/pull/647/files?diff=unified&w=0#diff-aa80e8c0a1efed4175a1fa0b2c43718ff8824c57f473db17c92b5635e9993edeL62))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
