### PR TITLE
fix: remove base component a11y label

### DIFF
--- a/src/components/site/BackToTopFAB.tsx
+++ b/src/components/site/BackToTopFAB.tsx
@@ -25,6 +25,7 @@ export const BackToTopFAB = () => {
   return (
     <FABBase
       id="to-top"
+      aria-label="Back to top"
       show={shouldShow}
       onClick={() => {
         window.scrollTo({

--- a/src/components/ui/FAB.tsx
+++ b/src/components/ui/FAB.tsx
@@ -64,7 +64,7 @@ export const FABBase = (
     >
   >,
 ) => {
-  const { children, id, show = true, ...extra } = props
+  const { children, show = true, ...extra } = props
   const { className, onTransitionEnd, ...rest } = extra
 
   const [mounted, setMounted] = useState(true)
@@ -98,7 +98,6 @@ export const FABBase = (
         className,
       )}
       onTransitionEnd={handleTransitionEnd}
-      aria-label="back to top"
       {...rest}
     >
       {children}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 156b033</samp>

The pull request simplifies the interface of the `FABBase` component and adds an `aria-label` attribute to the `BackToTopFAB` component. These changes enhance the accessibility and usability of the floating action buttons in the `src/components/ui` and `src/components/site` directories.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 156b033</samp>

> _To make the `BackToTopFAB` more clear_
> _We added an `aria-label` here_
> _And the `FABBase` component_
> _Had some props that were redundant_
> _So we removed them to avoid clutter and fear_

### WHY

Wrong a11y property setting on base component

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 156b033</samp>

* Improve accessibility and usability of `BackToTopFAB` component by adding `aria-label` attribute ([link](https://github.com/Crossbell-Box/xLog/pull/648/files?diff=unified&w=0#diff-eba52c8b223a7e6bed46fd053fa63e7bfcee59a2ba8a502510a598ac00700043R28))
* Simplify `FABBase` component interface by removing unused `id` prop ([link](https://github.com/Crossbell-Box/xLog/pull/648/files?diff=unified&w=0#diff-5a88abb6f102cf84869d4f48d055631ec1dd991b08053bc7f774707845311e5fL67-R67))
* Avoid confusion and duplication of accessibility label by removing `aria-label` attribute from `FABBase` component ([link](https://github.com/Crossbell-Box/xLog/pull/648/files?diff=unified&w=0#diff-5a88abb6f102cf84869d4f48d055631ec1dd991b08053bc7f774707845311e5fL101))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
