### PR TITLE
fix: xfeed url on homepage

### DIFF
--- a/src/components/home/Integrations.tsx
+++ b/src/components/home/Integrations.tsx
@@ -40,7 +40,7 @@ export function Integration() {
     {
       name: "xFeed",
       icon: <XFeedLogo className="w-full h-full" />,
-      url: "https://crossbell.io/feed",
+      url: "https://xfeed.app/",
     },
     {
       name: "xSync",


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5987e58</samp>

Updated the xFeed integration url in `Integrations.tsx` to match the new app domain name. This change aligns the home page with the rebranding of xFeed.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 5987e58</samp>

> _`xFeed` has new name_
> _Integration url changed_
> _Cutting ties with spring_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5987e58</samp>

* Updated the url of the xFeed integration to point to the new domain name ([link](https://github.com/Crossbell-Box/xLog/pull/663/files?diff=unified&w=0#diff-810dd78be7be359577dbf9e08c6d995959440d776dfea173b5afb94ea5760188L43-R43))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
