### PR TITLE
fix: opacity trickery for lcp

### DIFF
--- a/src/components/common/FadeIn.tsx
+++ b/src/components/common/FadeIn.tsx
@@ -30,7 +30,8 @@ const FadeIn = ({
       className={cn(
         "block transition-[opacity,transform] duration-800 ease-in-out",
         isInView === false && !locked
-          ? "opacity-0 translate-y-[20%]"
+          ? // @see https://www.debugbear.com/blog/opacity-animation-poor-lcp
+            "opacity-[0.00001] translate-y-[20%]"
           : "opacity-1 translate-y-0",
         className,
       )}


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 175b875</samp>

Improved web performance by reducing layout shifts caused by `FadeIn` component. Adjusted opacity value and added comment in `src/components/common/FadeIn.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 175b875</samp>

> _`opacity` tweak_
> _avoids layout shift in spring_
> _comment cites source_

### WHY

> Elements with an opacity of 0 are not LCP candidates
The [Core Web Vitals](https://www.debugbear.com/docs/metrics/core-web-vitals) measure user experience, so counting a paint with opacity 0 as the LCP element doesn't make sense.
>
> Accordingly, in August 2020 [Chrome made a change](https://bugs.chromium.org/p/chromium/issues/detail?id=1092473#c29) to ignore these elements.
>
>[LCP] Ignore paints with opacity 0
This changes the opacity 0 paints that are ignored by the LCP algorithm. [...] After this change, even will-change opacity paints are ignored, which could result in elements not becoming candidates because they are never repainted. In the special case where documentElement changes its opacity, we consider the largest content that becomes visible as a valid LCP candidate.
>
> Even after an element is faded in it still doesn't become an LCP candidate unless it is repainted. However, if an element is repainted then the LCP will be higher than expected!

Refer: https://www.debugbear.com/blog/opacity-animation-poor-lcp

> You could also start the fade-in animation with a non-zero opacity like 0.1, to ensure the initial render counts as an LCP candidate.

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 175b875</samp>

* Optimize the opacity value of the hidden element to avoid layout shift and LCP impact ([link](https://github.com/Crossbell-Box/xLog/pull/681/files?diff=unified&w=0#diff-95e7223f69561f3e6ad813438af8aa8db73ecf5040bb7d9aabd548e5347f6168L33-R34))
* Add a comment to explain the source of the optimization ([link](https://github.com/Crossbell-Box/xLog/pull/681/files?diff=unified&w=0#diff-95e7223f69561f3e6ad813438af8aa8db73ecf5040bb7d9aabd548e5347f6168L33-R34))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
