### PR TITLE
fix: caddy validator case sensitivity

### DIFF
--- a/deploy/dev/cm.yaml
+++ b/deploy/dev/cm.yaml
@@ -73,8 +73,10 @@ data:
             return Response(status=404)
         attributes = res.json().get("metadata", {}).get("content", {}).get("attributes", [])
         for d in attributes:
-            print(d)
-            if d.get("trait_type") == "xlog_custom_domain" and d.get("value") == domain:
-                return Response(status=200)
+            if d.get("trait_type") == "xlog_custom_domain":
+                print(d)
+                xlog_custom_domain = d.get("value", "").lower()
+                if xlog_custom_domain == domain:
+                    return Response(status=200)
 
         return Response(status=404)

--- a/deploy/prod/cm.yaml
+++ b/deploy/prod/cm.yaml
@@ -73,8 +73,10 @@ data:
             return Response(status=404)
         attributes = res.json().get("metadata", {}).get("content", {}).get("attributes", [])
         for d in attributes:
-            print(d)
-            if d.get("trait_type") == "xlog_custom_domain" and d.get("value") == domain:
-                return Response(status=200)
+            if d.get("trait_type") == "xlog_custom_domain":
+                print(d)
+                xlog_custom_domain = d.get("value", "").lower()
+                if xlog_custom_domain == domain:
+                    return Response(status=200)
 
         return Response(status=404)


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at faf5266</samp>

This pull request updates the logic of checking the `xlog_custom_domain` attribute in the `deploy/dev/cm.yaml` and `deploy/prod/cm.yaml` files. It makes the comparison case-insensitive to match the xLog API behavior.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at faf5266</samp>

> _`xlog_custom_domain`_
> _lowercased for comparison_
> _a winter bug fix_

### WHY

When determining the validity of a domain name, it should not be case-sensitive

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at faf5266</samp>

*  Make the comparison of xlog_custom_domain attribute case-insensitive in both dev and prod environments ([link](https://github.com/Crossbell-Box/xLog/pull/694/files?diff=unified&w=0#diff-03d5b89ef03551f2b7730c2d7193ac78da73d619b25cd6edb4c07586d3f910b3L76-R80), [link](https://github.com/Crossbell-Box/xLog/pull/694/files?diff=unified&w=0#diff-caecb698b916dfa7b615ca1b0ee2432f4163689f8a2fe212fb96edbe52732e1aL76-R80))
