### PR TITLE
fix: the image of avatar is displaying abnormally in HomeFeed & HomeS…

### DIFF
--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -169,7 +169,7 @@ const Post = ({
               >
                 <span className="w-10 h-10 inline-block">
                   <Image
-                    className="rounded-full"
+                    className="rounded-full object-cover"
                     src={
                       post.character?.metadata?.content?.avatars?.[0] ||
                       "ipfs://bafkreiabgixxp63pg64moxnsydz7hewmpdkxxi3kdsa4oqv4pb6qvwnmxa"

--- a/src/components/home/HomeSidebar.tsx
+++ b/src/components/home/HomeSidebar.tsx
@@ -79,7 +79,7 @@ export function HomeSidebar({ hideSearch }: { hideSearch?: boolean }) {
                   <CharacterFloatCard siteId={site.handle}>
                     <span className="w-10 h-10 inline-block">
                       <Image
-                        className="rounded-full"
+                        className="rounded-full object-cover"
                         src={
                           site?.metadata?.content?.avatars?.[0] ||
                           "ipfs://bafkreiabgixxp63pg64moxnsydz7hewmpdkxxi3kdsa4oqv4pb6qvwnmxa"


### PR DESCRIPTION
…idebar

### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e350127</samp>

Added the `object-cover` class to `Image` components in `HomeFeed.tsx` and `HomeSidebar.tsx` to improve the cropping of avatar images. This change enhances the UI of the home page.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e350127</samp>

> _`object-cover` crops_
> _images to fit round shapes_
> _autumn leaves are crisp_

### WHY
When the intrinsic size ratio of the avatar image is not 1:1, abnormal display occurs. 
![image](https://github.com/Crossbell-Box/xLog/assets/18499412/2477f2c8-4d4e-4b69-831d-d6ad3ae1133f)
Abnormal behavior
![image](https://github.com/Crossbell-Box/xLog/assets/18499412/d1908206-7758-46ba-b3fd-111ae31f4cd1)
after repair
![image](https://github.com/Crossbell-Box/xLog/assets/18499412/e1cfe943-d809-40a5-aa93-e5bf0cb951af)
I have added this fix to activities and suggested creators
Perhaps adding a cropping feature at the point of submitting the avatar image can fundamentally solve this problem.


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e350127</samp>

*  Added `object-cover` class to `Image` components to crop avatar images to fit rounded shapes in the home feed and sidebar ([link](https://github.com/Crossbell-Box/xLog/pull/698/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dL172-R172), [link](https://github.com/Crossbell-Box/xLog/pull/698/files?diff=unified&w=0#diff-51e00f6979033f8ca3540639ac61d3cd03d2126f41d4cb25c8db54a69c2130b7L82-R82))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
