### PR TITLE
fix: `getNFTs` might return null and cause pages to crash

### DIFF
--- a/src/app/site/[site]/nft/page.tsx
+++ b/src/app/site/[site]/nft/page.tsx
@@ -38,7 +38,7 @@ export default async function SiteNFTPage({
   const site = await fetchGetSite(params.site, queryClient)
   const { t } = await useTranslation("common")
 
-  let nfts = await getNFTs(site?.owner)
+  let nfts = (await getNFTs(site?.owner)) ?? []
 
   nfts.forEach((chain: any) => {
     chain.assets = []


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ec39049</samp>

Fix a potential bug and enhance the UI of the NFT page. Use `??` operator to handle nullish values in `nfts` array in `src/app/site/[site]/nft/page.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at ec39049</samp>

> _`nfts` may be null_
> _Use coalescing operator_
> _Winter bug fixing_

### WHY
<!-- author to complete -->

### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ec39049</samp>

*  Prevent errors when calling forEach on nullish values by using nullish coalescing operator (??) to assign empty arrays to nfts and collections ([link](https://github.com/Crossbell-Box/xLog/pull/735/files?diff=unified&w=0#diff-d2078792ff17cf1f26543074f8913ba18f436e2648576e17d1991f5e07e8f241L41-R41),   )

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
