### PR TITLE
feat: disable PostModal when detecting arc browser

### DIFF
--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -48,12 +48,16 @@ const PostCard = ({
   const { t } = useTranslation("common")
   const date = useDate()
   const isMobileLayout = useIsMobileLayout()
+  const isArcBrowser = !!window
+    .getComputedStyle(document.documentElement)
+    .getPropertyValue("--arc-palette-title")
+  const isPostModalDisabled = isMobileLayout || isArcBrowser
 
   return (
     <Link
-      target={isMobileLayout ? "_blank" : undefined}
+      target={isPostModalDisabled ? "_blank" : undefined}
       href={
-        isMobileLayout
+        isPostModalDisabled
           ? `/site/${post?.character?.handle}/${post.metadata?.content?.slug}`
           : `/post/${post?.character?.handle}/${post.metadata?.content?.slug}`
       }


### PR DESCRIPTION
### WHAT
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a24b77</samp>

Modified `PostCard` component to handle Arc browser compatibility. Added a condition to disable post modal and open post link in a new tab if the browser is Arc or the screen is small.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 4a24b77</samp>

> _`PostCard` adapts_
> _To Arc browser and screen size_
> _Modal or new tab?_

### WHY
In Arc browser, user need to click twice to open post page.

![CleanShot 2023-07-07 at 16 54 56](https://github.com/Crossbell-Box/xLog/assets/4584859/3fb0f52b-6ef9-4fc5-8df6-957883acbf3a)


### HOW
<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 4a24b77</samp>

*  Disable post modal for Arc browser and mobile layout ([link](https://github.com/Crossbell-Box/xLog/pull/746/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dL51-R60))

### CLAIM REWARDS
<!-- author to complete -->
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
