### PR TITLE
fix: dark mode flash if no cookie found

### DIFF
--- a/src/app/ColorSchemeInjector.tsx
+++ b/src/app/ColorSchemeInjector.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import { useServerInsertedHTML } from "next/navigation"
+
+import {
+  COLOR_SCHEME_DARK,
+  COLOR_SCHEME_LIGHT,
+  DARK_MODE_STORAGE_KEY,
+} from "~/lib/constants"
+import { getStorage } from "~/lib/storage"
+
+export const ColorSchemeInjector = () => {
+  useServerInsertedHTML(() => {
+    return (
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `(() => {
+var DARK_MODE_STORAGE_KEY = "${DARK_MODE_STORAGE_KEY}";
+var getStorage = ${getStorage.toString()};
+var COLOR_SCHEME_LIGHT = "${COLOR_SCHEME_LIGHT}";
+var COLOR_SCHEME_DARK = "${COLOR_SCHEME_DARK}";
+
+let data = {}
+const isDark = getStorage(DARK_MODE_STORAGE_KEY)
+if (typeof isDark === "undefined") {
+  const currentColorScheme = window.matchMedia("(prefers-color-scheme: dark)")
+    .matches
+    ? COLOR_SCHEME_DARK
+    : COLOR_SCHEME_LIGHT
+  document.documentElement.classList.add(currentColorScheme)
+} else {
+  document.documentElement.classList.add(
+    isDark ? COLOR_SCHEME_DARK : COLOR_SCHEME_LIGHT,
+  )
+}
+})();`,
+        }}
+      ></script>
+    )
+  })
+  return null
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { getAcceptLang } from "~/lib/accept-lang"
 import { APP_DESCRIPTION, APP_NAME, APP_SLOGAN, SITE_URL } from "~/lib/env"
 import { getColorScheme } from "~/lib/get-color-scheme"
 
+import { ColorSchemeInjector } from "./ColorSchemeInjector"
 import Providers from "./providers"
 
 export const metadata: Metadata = {
@@ -95,7 +96,13 @@ export default function RootLayout({
   }
 
   return (
-    <html lang={lang} dir={dir(lang)} className={colorScheme}>
+    <html
+      lang={lang}
+      dir={dir(lang)}
+      className={colorScheme}
+      suppressHydrationWarning
+    >
+      <ColorSchemeInjector />
       <body>
         <Providers lang={lang}>
           {modal}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,3 +16,4 @@ export const MAXIMUM_FILE_SIZE = 100 // MB
 export const COLOR_SCHEME_DARK = "dark"
 export const COLOR_SCHEME_LIGHT = "light"
 export const DEFAULT_COLOR_SCHEME: ColorScheme = "light"
+export const DARK_MODE_STORAGE_KEY = "darkMode"

--- a/src/lib/get-color-scheme.ts
+++ b/src/lib/get-color-scheme.ts
@@ -1,7 +1,6 @@
 import { cookies } from "next/headers"
 
-import { DEFAULT_COLOR_SCHEME } from "./constants"
 import { ColorScheme } from "./types"
 
 export const getColorScheme = () =>
-  (cookies().get("color_scheme")?.value || DEFAULT_COLOR_SCHEME) as ColorScheme
+  cookies().get("color_scheme")?.value as ColorScheme


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d75c36c</samp>

This pull request adds a new component `ColorSchemeInjector` to enable dynamic color schemes for the pages based on the user's preference or system setting. It also refactors the `useDarkMode` hook and the `get-color-scheme` function to use a single constant `DARK_MODE_STORAGE_KEY` for the local storage key of the dark mode state. Additionally, it fixes a hydration issue with the `ColorSchemeInjector` component.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at d75c36c</samp>

> _`ColorSchemeInjector`_
> _Injects a script for theme_
> _A winter solstice_

### WHY

Fixed page flashing in system dark mode caused by no cookies in the initial state.

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d75c36c</samp>

*  Add a new component `ColorSchemeInjector` to inject a script tag for the initial color scheme class ([link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-a332bfd4983c99f9951aabb32ff5bc03cca3634a7c5b75c48a43576feadd0dabR1-R42))
*  Import and render `ColorSchemeInjector` in the base layout component `layout.tsx` and suppress hydration warning ([link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R14), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L98-R105))
*  Refactor the custom hook `useDarkMode.ts` to use the constant `DARK_MODE_STORAGE_KEY` from `constants.ts` instead of a variable or parameter ([link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0R7), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L33-R36), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L45), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L54-R53), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L61-R64), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L71-R75), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L97-R96), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L107-R106), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L169-R169), [link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-2047312bd1019e8eb8a5db53adac4005b498148357ba5184c72fb95e071a5ed0L187-R199))
*  Add the constant `DARK_MODE_STORAGE_KEY` to `constants.ts` to store the local storage key for the dark mode value ([link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-8c943ccfb5928fff63708e99eaafa93f8845c9405ed8e4b32afed23e5003025aR19))
*  Remove the constant `DEFAULT_COLOR_SCHEME` from `get-color-scheme.ts` as it is no longer needed ([link](https://github.com/Crossbell-Box/xLog/pull/779/files?diff=unified&w=0#diff-3107c54eff7dbbe1b67631e1600f8fc97a9babd493d89b56e9bec37e1c7346d6L3-R6))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
