### PR TITLE
fix: to fix the mistakes I have made about react

### DIFF
--- a/src/app/ColorSchemeInjector.tsx
+++ b/src/app/ColorSchemeInjector.tsx
@@ -7,7 +7,6 @@ import {
   COLOR_SCHEME_LIGHT,
   DARK_MODE_STORAGE_KEY,
 } from "~/lib/constants"
-import { getStorage } from "~/lib/storage"
 
 export const ColorSchemeInjector = () => {
   useServerInsertedHTML(() => {
@@ -16,7 +15,14 @@ export const ColorSchemeInjector = () => {
         dangerouslySetInnerHTML={{
           __html: `(() => {
 var DARK_MODE_STORAGE_KEY = "${DARK_MODE_STORAGE_KEY}";
-var getStorage = ${getStorage.toString()};
+var namespace = "xlog"
+var getStorage = () => {
+  const data = {}
+  try {
+    data = JSON.parse(localStorage.getItem(namespace) || "{}")
+  } catch (error) {}
+  return data
+}
 var COLOR_SCHEME_LIGHT = "${COLOR_SCHEME_LIGHT}";
 var COLOR_SCHEME_DARK = "${COLOR_SCHEME_DARK}";
 

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -34,6 +34,7 @@ const colorScheme: NotificationModalColorScheme = {
   border: `var(--border-color)`,
 }
 
+const createQueryClient = () => new QueryClient()
 export default function Providers({
   children,
   lang,
@@ -45,7 +46,7 @@ export default function Providers({
   useMobileLayout()
   useNProgress()
 
-  const [queryClient] = useState(() => new QueryClient())
+  const [queryClient] = useState(createQueryClient)
 
   return (
     <WagmiConfig config={wagmiConfig}>

--- a/src/hooks/useRefValue.ts
+++ b/src/hooks/useRefValue.ts
@@ -1,0 +1,15 @@
+import { useRef } from "react"
+
+// @see https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents
+export const useRefValue = <T>(value: () => T): T => {
+  const ref = useRef<T>()
+
+  const onceRef = useRef(false)
+
+  if (!onceRef.current) {
+    ref.current = value()
+    onceRef.current = true
+  }
+
+  return ref.current!
+}


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c0b4e74</samp>

This pull request improves the browser compatibility, code quality, and efficiency of the `Crossbell-Box/xLog` app. It removes an unnecessary dependency in `ColorSchemeInjector.tsx`, refactors the query client creation and router event listener logic in `src/app/providers.tsx` and `src/hooks/useRouterEvents.ts`, and adds a new custom hook `useRefValue` in `src/hooks/useRefValue.ts` to avoid recreating the ref contents.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at c0b4e74</samp>

> _We create the hooks of doom_
> _To avoid the ref contents' gloom_
> _We refactor and simplify_
> _To make the code fly_

### WHY

Today I found out that I can't react at all, and I'm sorry

https://react.dev/reference/react/useRef#avoiding-recreating-the-ref-contents

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at c0b4e74</samp>

*  Simplify the logic of registering and unregistering router event listeners using a custom hook and a helper function ([link](https://github.com/Crossbell-Box/xLog/pull/791/files?diff=unified&w=0#diff-6957d619dc7576122e6f9d768bf4aeeaff01aaa81cf25852b672f3502359b9c9L2-R41), [link](https://github.com/Crossbell-Box/xLog/pull/791/files?diff=unified&w=0#diff-6957d619dc7576122e6f9d768bf4aeeaff01aaa81cf25852b672f3502359b9c9L16-R48), [link](https://github.com/Crossbell-Box/xLog/pull/791/files?diff=unified&w=0#diff-6957d619dc7576122e6f9d768bf4aeeaff01aaa81cf25852b672f3502359b9c9L51-R84), [link](https://github.com/Crossbell-Box/xLog/pull/791/files?diff=unified&w=0#diff-6957d619dc7576122e6f9d768bf4aeeaff01aaa81cf25852b672f3502359b9c9L81-R94), [link](https://github.com/Crossbell-Box/xLog/pull/791/files?diff=unified&w=0#diff-6957d619dc7576122e6f9d768bf4aeeaff01aaa81cf25852b672f3502359b9c9L97-R110)) in `src/hooks/useRouterEvents.ts`

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
