### PR TITLE
fix: dashboard sidebar icon

### DIFF
--- a/src/app/dashboard/[subdomain]/layout-component.tsx
+++ b/src/app/dashboard/[subdomain]/layout-component.tsx
@@ -346,7 +346,7 @@ export default function DashboardLayout({
                                 : link.href || link.onClick
                                 ? "hover:bg-slate-200 hover:bg-opacity-50"
                                 : "opacity-80",
-                              !isOpen && "justify-center",
+                              !isOpen && "justify-center px-0",
                             )}
                             onClick={link.onClick}
                           >


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 928c96e</samp>

Added `px-0` class to sidebar links in `layout-component.tsx` to improve UI design and responsiveness. This change affects the dashboard layout for different subdomains.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 928c96e</samp>

> _`px-0` class added_
> _sidebar icons more centered_
> _autumn leaves design_

### WHY
Before:
<img width="103" alt="CleanShot 2023-07-24 at 23 39 10@2x" src="https://github.com/Crossbell-Box/xLog/assets/4584859/7160a2cf-12f0-4c6b-b09c-80b5a4018d79">

After:
<img width="106" alt="CleanShot 2023-07-24 at 23 37 26@2x" src="https://github.com/Crossbell-Box/xLog/assets/4584859/308a8f25-a63c-4c28-b574-18867ac70826">

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 928c96e</samp>

*  Remove horizontal padding from sidebar links when collapsed ([link](https://github.com/Crossbell-Box/xLog/pull/815/files?diff=unified&w=0#diff-998c23e4b923ca2f9f8f76529de0639fb3ce4829b3f9a81b0df40e64b3511d28L349-R349))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
