### PR TITLE
fix: resolve issue with NFTs content_uri starting with svg

### DIFF
--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -72,7 +72,7 @@ async function getScore(cid: string) {
     noUpdate: true,
     noExpire: true,
     getValueFun: async () => {
-      let resut
+      let result
       await lock.acquire(cid, async () => {
         const meta = await prisma.metadata.findFirst({
           where: {
@@ -81,7 +81,7 @@ async function getScore(cid: string) {
         })
         if (meta) {
           if (meta?.ai_score !== null) {
-            resut = {
+            result = {
               number: meta.ai_score,
               reason: meta.ai_score_reason,
             }
@@ -98,7 +98,7 @@ async function getScore(cid: string) {
                 },
               })
 
-              resut = score
+              result = score
             }
           }
         } else {
@@ -112,11 +112,11 @@ async function getScore(cid: string) {
               },
             })
 
-            resut = score
+            result = score
           }
         }
       })
-      return resut
+      return result
     },
   })
 

--- a/src/app/site/[site]/nft/page.tsx
+++ b/src/app/site/[site]/nft/page.tsx
@@ -109,6 +109,10 @@ export default async function SiteNFTPage({
                         nft.content_uri?.startsWith?.("http") ||
                         nft.content_uri?.startsWith?.("data:")
                           ? nft.content_uri
+                          : nft.content_uri?.startsWith?.("<svg")
+                          ? `data:image/svg+xml,${encodeURIComponent(
+                              nft.content_uri,
+                            )}` || ""
                           : toGateway(`ipfs://${nft.content_uri}`) || ""
                       }
                       mime_type={nft.content_type}


### PR DESCRIPTION
### Before

In production mode:

<img width="1038" alt="Screenshot 2023-08-04 at 18 07 14" src="https://github.com/Crossbell-Box/xLog/assets/47740312/d88fcf23-8fb1-435c-bc19-a3a8cc5deb9f">


### After

In development mode:

<img width="1155" alt="Screenshot 2023-08-05 at 18 40 18" src="https://github.com/Crossbell-Box/xLog/assets/47740312/54412085-953c-4fb9-9b14-d03e02a3359a">


### PS

By the way, I corrected the variable naming error in `src/app/api/score/route.ts` ...
