### PR TITLE
fix: share to twitter get 400 Issue #881

### DIFF
--- a/src/components/common/ReactionShare.tsx
+++ b/src/components/common/ReactionShare.tsx
@@ -35,7 +35,9 @@ const shareList = [
     ),
     onClick: (data: ShareData) => {
       window.open(
-        `https://twitter.com/intent/tweet?url=${data.url}&text=${data.text}&via=_xLog`,
+        `https://twitter.com/intent/tweet?url=${encodeURIComponent(
+          data.url,
+        )}&text=${encodeURIComponent(data.text)}&via=_xLog`,
       )
     },
   },


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95a9ee2</samp>

Fixed Twitter share button URL encoding in `ReactionShare` component. Used `encodeURIComponent` to format and escape `data.url` and `data.text` parameters for the Twitter share URL in `src/components/common/ReactionShare.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 95a9ee2</samp>

> _Share content with ease_
> _`encodeURIComponent`_
> _Winter's URL_

### WHY

<!-- author to complete -->

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 95a9ee2</samp>

*  Encode URL and text parameters for Twitter share button to avoid errors ([link](https://github.com/Crossbell-Box/xLog/pull/882/files?diff=unified&w=0#diff-383b3eebcdafd70d2bcccef97bf90bec13fb47c0b6fdef6ea2c556464531db34L38-R40))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
