### PR TITLE
feat: limit code block area height

### DIFF
--- a/src/css/code.css
+++ b/src/css/code.css
@@ -5,6 +5,7 @@ pre {
   background-color: var(--code-bg);
   color: var(--code-fg);
   @apply text-sm;
+  @apply scrollbar-hide overflow-y-auto max-h-[30.5em];
 }
 
 :not(pre) > code {


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f96ab6c</samp>

Improved the UI of code snippets in xLog by applying Tailwind CSS utility classes to `code.css`. This hides the scrollbar, enables vertical scrolling, and limits the maximum height of the code block.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at f96ab6c</samp>

> _`code` class refined_
> _scrollbar hidden, height capped_
> _winter of xLog_

### WHY

close #734 

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f96ab6c</samp>

* Hide the scrollbar, enable vertical scrolling, and limit the maximum height of the code block for the `.code` class using Tailwind CSS utility classes ([link](https://github.com/Crossbell-Box/xLog/pull/890/files?diff=unified&w=0#diff-fa86f55868bc0c11d88a834237eebfa50a323f05cd804236e3fc21d5404ed408R8))

### CLAIM REWARDS

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
