### PR TITLE
feat: bilibili video link parser support specific episode selection

### DIFF
--- a/src/markdown/embed-transformers/Bilibili.ts
+++ b/src/markdown/embed-transformers/Bilibili.ts
@@ -16,12 +16,15 @@ const getTimeValueInSeconds = (timeValue: string) => {
 }
 
 const getBilibiliIFrameSrc = (url: URL) => {
-  const match = url.pathname.match(/\/video\/([A-Za-z0-9]+)\//)
+  const match = url.pathname.match(/\/video\/([A-Za-z0-9]+)\/?/)
   if (!match || match.length < 1) return
   const bvid = match[1]
 
+  const page = url.searchParams.get('p')
+  const pageParam = (page) ? `&page=${page}` : ''
+
   const embedUrl = new URL(
-    `https://player.bilibili.com/player.html?bvid=${bvid}&autoplay=false`,
+    `https://player.bilibili.com/player.html?bvid=${bvid}&autoplay=false` + pageParam,
   )
 
   return embedUrl.toString()


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 076ae33</samp>

Improved Bilibili embed transformer to handle multi-part videos. Added support for page parameter in `getBilibiliIFrameSrc` function in `src/markdown/embed-transformers/Bilibili.ts`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 076ae33</samp>

> _`getBilibiliIFrameSrc`_
> _Handles page parameter now_
> _Autumn of changes_

### WHY

This resolves issue #883

Actually, iframe player provided by bilibili official can indeed support episode selection, as long as we specify its page number parameter in url links (see image below). Therefore, I updated the bilibili link parser in the code.
![image](https://github.com/Crossbell-Box/xLog/assets/56473405/5c24cd7b-264e-4ff0-a268-4ea0955deda1)


### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 076ae33</samp>

*  Support optional page parameter for Bilibili video embeds ([link](https://github.com/Crossbell-Box/xLog/pull/892/files?diff=unified&w=0#diff-aef698012f2542fdd3e2786e6f4fca43d7593fae113b428a03639d78af1ed2beL19-R27))

### CLAIM REWARDS

xLog address:  0x1e19473e83AD0aCdcDf3BD2b216AB7c505F2f2ec
Discord ID: yebt

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
