### PR TITLE
fix: import a file when file name only have number like 2021.md will …

### DIFF
--- a/src/app/dashboard/[subdomain]/editor/post-editor.tsx
+++ b/src/app/dashboard/[subdomain]/editor/post-editor.tsx
@@ -188,7 +188,7 @@ export default function PostEditor() {
       if (key === "title") {
         setDefaultSlug(
           getDefaultSlug(
-            value as string,
+            value as string[],
             draftKey.replace(`draft-${site.data?.characterId}-`, ""),
           ),
         )
@@ -385,7 +385,7 @@ export default function PostEditor() {
     })
     setDefaultSlug(
       getDefaultSlug(
-        page.data.metadata?.content?.title || "",
+        (page.data.metadata?.content?.title as unknown as string[]) || [],
         draftKey.replace(`draft-${site.data?.characterId}-`, ""),
       ),
     )

--- a/src/lib/default-slug.ts
+++ b/src/lib/default-slug.ts
@@ -1,19 +1,28 @@
 import { pinyin } from "pinyin-pro"
 
-export const getDefaultSlug = (title: string, id?: string) => {
-  let generated =
-    pinyin(title, {
-      toneType: "none",
-      type: "array",
-      nonZh: "consecutive",
-    })
-      ?.map((word) => word.trim())
+export const getDefaultSlug = (titleArray: string[], id?: string) => {
+  const title = titleArray[0]
+
+  const pinyinArray = pinyin(title, {
+    toneType: "none",
+    type: "array",
+    nonZh: "consecutive",
+  })
+
+  const generated =
+    pinyinArray
+      ?.map((word) => word[0].trim())
       ?.filter((word) => word)
       ?.join("-")
       ?.replace(/\s+/g, "-") ||
     id?.replace(`!local-`, "")?.replace(`local-`, "") ||
     ""
-  generated = generated.replace(/[^a-zA-Z0-9\s-_]/g, "")
 
-  return generated
+  const cleanedGenerated = generated.replace(/[^a-zA-Z0-9\s-_]/g, "")
+
+  if (cleanedGenerated && cleanedGenerated.split("-").length === 1) {
+    return cleanedGenerated + "-"
+  }
+
+  return cleanedGenerated
 }


### PR DESCRIPTION
…get Application error: a client-side exception has occurred (see the browser console for more information)

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55ed2ca</samp>

Improved slug generation for multilingual posts. Moved and refactored `getDefaultSlug` function to `src/lib/default-slug.ts` and updated its usage in `post-editor.tsx`.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 55ed2ca</samp>

> _To handle titles in many tongues_
> _The `getDefaultSlug` function was wrung_
> _It moved to a new place_
> _And improved its slug base_
> _Now the posts have URLs that are fun_

### WHY

<!-- author to complete -->

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55ed2ca</samp>

*  Move and modify `getDefaultSlug` function to accept an array of strings as the title parameter and use only the first character of each pinyin word to generate the slug ([link](https://github.com/Crossbell-Box/xLog/pull/909/files?diff=unified&w=0#diff-c89ef0e90cf7d0575969a78ae2b8c4edeeb284cb8c7301c6d7a3e2d4ba41bd2aL3-R14), [link](https://github.com/Crossbell-Box/xLog/pull/909/files?diff=unified&w=0#diff-46d42aecfcde90db54ab62e00c4601540f9e7f4f7219423bebda09b32def6970L191-R191), [link](https://github.com/Crossbell-Box/xLog/pull/909/files?diff=unified&w=0#diff-c89ef0e90cf7d0575969a78ae2b8c4edeeb284cb8c7301c6d7a3e2d4ba41bd2aL16-R27))
*  Append a dash to the slug if it only has one word and assign it to a new variable to avoid mutation ([link](https://github.com/Crossbell-Box/xLog/pull/909/files?diff=unified&w=0#diff-c89ef0e90cf7d0575969a78ae2b8c4edeeb284cb8c7301c6d7a3e2d4ba41bd2aL16-R27))
*  Update the call of `getDefaultSlug` in the `useEffect` hook of `post-editor.tsx` to cast the title as an array of strings and provide a fallback empty array ([link](https://github.com/Crossbell-Box/xLog/pull/909/files?diff=unified&w=0#diff-46d42aecfcde90db54ab62e00c4601540f9e7f4f7219423bebda09b32def6970L388-R388))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
