### PR TITLE
fix: import a file when file name only have number like 2021.md will …

### DIFF
--- a/src/lib/default-slug.ts
+++ b/src/lib/default-slug.ts
@@ -2,7 +2,7 @@ import { pinyin } from "pinyin-pro"
 
 export const getDefaultSlug = (title: string, id?: string) => {
   let generated =
-    pinyin(title, {
+    pinyin(String(title), {
       toneType: "none",
       type: "array",
       nonZh: "consecutive",


### PR DESCRIPTION
…get Application error: a client-side exception has occurred (see the browser console for more information)

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04ce30d</samp>

Fixed a bug in `getDefaultSlug` that caused errors when creating posts without titles. Added a string cast to the `title` parameter before using the `pinyin` function.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 04ce30d</samp>

> _`getDefaultSlug` changed_
> _cast `title` to string first_
> _avoid winter bugs_

### WHY

<!-- author to complete -->

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 04ce30d</samp>

*  Cast `title` to string before calling `pinyin` to avoid errors with null or undefined values ([link](https://github.com/Crossbell-Box/xLog/pull/914/files?diff=unified&w=0#diff-c89ef0e90cf7d0575969a78ae2b8c4edeeb284cb8c7301c6d7a3e2d4ba41bd2aL5-R5))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
