### PR TITLE
fix: do post will call back Error while usePostNote Cannot convert nu…

### DIFF
--- a/src/queries/page.ts
+++ b/src/queries/page.ts
@@ -234,6 +234,10 @@ export function useCreatePage() {
         throw new Error("characterId is required")
       }
 
+      if (!postNote.mutate) {
+        throw new Error("postNote.mutate is required")
+      }
+
       return postNote.mutate(
         {
           characterId: input.characterId,


### PR DESCRIPTION
…ll to BigInt

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 91b5603</samp>

Add validation check to `useCreatePage` hook in `src/queries/page.ts`. This prevents creating a new page with an invalid `postNote` object.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 91b5603</samp>

> _`useCreatePage` hook_
> _validates `postNote` object_
> _error in winter_

### WHY

<!-- author to complete -->

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 91b5603</samp>

* Add a validation check to `useCreatePage` hook to ensure `postNote` object has a `mutate` function ([link](https://github.com/Crossbell-Box/xLog/pull/915/files?diff=unified&w=0#diff-4e13f8f8c28dbf6ccc0a9b72ab90fee045a95281b105455501615a63426611d6R237-R240))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
