### PR TITLE
ci: caddy prom

### DIFF
--- a/deploy/prod/deploy.yaml
+++ b/deploy/prod/deploy.yaml
@@ -91,6 +91,10 @@ spec:
     metadata:
       labels:
         app: xlog-caddy
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8080"
+        prometheus.io/scrape: "true"
     spec:
       containers:
         - name: caddy


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7473c12</samp>

This pull request enhances the xlog deployment in the prod environment by adding `Prometheus` metrics and fixing a configMap error.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7473c12</samp>

> _To monitor xlog with ease_
> _We added Prometheus metrics, please_
> _We also fixed a typo_
> _In the validator's configMap, oh_
> _Now the system is more secure and at peace_

### WHY

Collect prom metrics for caddy

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7473c12</samp>

*  Enable Prometheus scraping of xlog metrics by adding annotations to the xlog deployment ([link](https://github.com/Crossbell-Box/xLog/pull/965/files?diff=unified&w=0#diff-3c631447f79e3bf30a0d5f6a521b3cd281a9e84fa508f07448dcfbc180c6cf98R94-R97))
*  Fix typo in the name of the configMap for the validator service Caddy configuration ([link](https://github.com/Crossbell-Box/xLog/pull/965/files?diff=unified&w=0#diff-3c631447f79e3bf30a0d5f6a521b3cd281a9e84fa508f07448dcfbc180c6cf98L142-R146))
