### PR TITLE
feat: load more button

### DIFF
--- a/src/components/home/HomeFeed.tsx
+++ b/src/components/home/HomeFeed.tsx
@@ -8,6 +8,7 @@ import { useAccountState, useConnectModal } from "@crossbell/connect-kit"
 import { Switch } from "@headlessui/react"
 
 import PostCard from "~/components/common/PostCard"
+import { Button } from "~/components/ui/Button"
 import { EmptyState } from "~/components/ui/EmptyState"
 import { Skeleton } from "~/components/ui/Skeleton"
 import { Tabs } from "~/components/ui/Tabs"
@@ -208,7 +209,6 @@ export const HomeFeed = ({ type }: { type?: FeedType }) => {
             <VirtuosoGrid
               initialItemCount={9}
               overscan={2604}
-              endReached={() => feed.hasNextPage && feed.fetchNextPage()}
               useWindowScroll
               data={feedInOne}
               totalCount={feed.data?.pages[0]?.count || 0}
@@ -238,7 +238,14 @@ export const HomeFeed = ({ type }: { type?: FeedType }) => {
               }}
             ></VirtuosoGrid>
 
-            {feed.isFetching && feed.hasNextPage && isMounted && <Loader />}
+            {feed.hasNextPage && isMounted && (
+              <LoadMore
+                isLoading={feed.isFetching}
+                onClick={() => {
+                  feed.fetchNextPage()
+                }}
+              />
+            )}
           </div>
         )}
       </div>
@@ -246,14 +253,22 @@ export const HomeFeed = ({ type }: { type?: FeedType }) => {
   )
 }
 
-const Loader = () => {
+const LoadMore = ({
+  onClick,
+  isLoading,
+}: {
+  isLoading: boolean
+  onClick: () => void
+}) => {
   const { t } = useTranslation("common")
   return (
     <div
-      className="relative w-full text-sm text-center py-4 mt-12"
-      key={"loading"}
+      className="relative w-full text-sm text-center mt-12"
+      key={"load-more"}
     >
-      {t("Loading")} ...
+      <Button onClick={onClick} isLoading={isLoading}>
+        {isLoading ? t("Loading") : t("Load more")}
+      </Button>
     </div>
   )
 }

--- a/src/lib/i18n/locales/ja/common.json
+++ b/src/lib/i18n/locales/ja/common.json
@@ -52,6 +52,7 @@
   "Upgrade to Wallet": "ウォレットにアップグレード",
   "Disconnect": "中断する",
   "Loading": "読み込み中",
+  "Load more": "もっと読み込む",
   "Showcase": "ショーケース",
   "AI-generated summary": "AI が生成した要約",
   "Generating": "生成中",

--- a/src/lib/i18n/locales/zh-TW/common.json
+++ b/src/lib/i18n/locales/zh-TW/common.json
@@ -57,6 +57,7 @@
   "Upgrade to Wallet": "升級為錢包認證",
   "Disconnect": "中斷連線",
   "Loading": "載入中...",
+  "Load more": "載入更多",
   "Showcase": "展示櫃",
   "AI-generated summary": "AI 生成的摘要",
   "Generating": "生成中...",

--- a/src/lib/i18n/locales/zh/common.json
+++ b/src/lib/i18n/locales/zh/common.json
@@ -60,6 +60,7 @@
   "Upgrade to Wallet": "升级为钱包",
   "Disconnect": "断开连接",
   "Loading": "加载中",
+  "Load more": "加载更多",
   "Showcase": "展示柜",
   "AI-generated summary": "AI 生成的摘要",
   "Generating": "生成中",


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bf0847e</samp>

This pull request adds manual pagination to the home feed component by using a `LoadMore` button. It also updates the `common.json` files for the Japanese, Traditional Chinese, and Simplified Chinese locales with the corresponding translation for the button text.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at bf0847e</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A new way to display the endless stream of posts_
> _That fill the home feed of the users, eager-eyed,_
> _And who in many tongues the `LoadMore` component boasts._

### WHY

Scroll to load more prevents users from seeing the footer on the homepage and may cause unnecessary network requests.

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at bf0847e</samp>

* Import `Button` component to use in `LoadMore` component ([link](https://github.com/Crossbell-Box/xLog/pull/992/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dR11))
* Replace `endReached` prop of `VirtuosoGrid` with `LoadMore` component that handles pagination logic ([link](https://github.com/Crossbell-Box/xLog/pull/992/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dL211), [link](https://github.com/Crossbell-Box/xLog/pull/992/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dL241-R248))
* Define `LoadMore` component that renders a button with loading indicator and localized text for fetching next page of feed ([link](https://github.com/Crossbell-Box/xLog/pull/992/files?diff=unified&w=0#diff-31b4e89d16808fe3e482596bf15b704c85d259bf6b5f19d7b421f9b1061bd40dL249-R271))
* Add translations for "Load more" text in Japanese, Traditional Chinese, and Simplified Chinese ([link](https://github.com/Crossbell-Box/xLog/pull/992/files?diff=unified&w=0#diff-18e74aadabe233f19a9bd8666de5d391403dbd4a64559ca2fe4444063fcd50b9R55), [link](https://github.com/Crossbell-Box/xLog/pull/992/files?diff=unified&w=0#diff-75883a425ae492cba54b218eb2c414d5108cec59f12f22813204a53c12dde906R60), [link](https://github.com/Crossbell-Box/xLog/pull/992/files?diff=unified&w=0#diff-30b22c41fb54d288af54f7f82ab309d480721b5575fb2e4cd457050e6e3707caR63))

### CLAIM REWARDS

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
