### PR TITLE
ci(deploy): rm nodeSelector

### DIFF
--- a/deploy/prod/deploy.yaml
+++ b/deploy/prod/deploy.yaml
@@ -25,8 +25,6 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       enableServiceLinks: false
-      nodeSelector:
-        rss3.io/usage: csb-others
       tolerations:
         - key: "rss3.io/usage"
           operator: "Equal"


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 22ef7d6</samp>

Removed node selector for xLog deployment in `deploy/prod/deploy.yaml`. This enables the service to run on any node and improves availability and scalability.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 22ef7d6</samp>

> _`xLog` can run now_
> _On any node in cluster_
> _Autumn wind of change_

### WHY

The resources of the dedicated node are not enough, remove the nodeSelector so that it can be deployed on any node.

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 22ef7d6</samp>

* Remove node selector for xLog deployment to increase availability and scalability ([link](https://github.com/Crossbell-Box/xLog/pull/999/files?diff=unified&w=0#diff-3c631447f79e3bf30a0d5f6a521b3cd281a9e84fa508f07448dcfbc180c6cf98L28-L29))
