### PR TITLE
Fix/editor find style

### DIFF
--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -318,6 +318,11 @@ a {
   @apply border-accent;
 }
 
+.monaco-inputbox .input:focus {
+  @apply shadow-none;
+  --tw-ring-shadow: none;
+}
+
 .input.is-block {
   @apply w-full;
 }

--- a/src/css/tailwind.css
+++ b/src/css/tailwind.css
@@ -100,7 +100,8 @@ a {
   @apply focus-ring focus-within:ring-offset-1;
 }
 
-.button.is-auto-width {
+.button.is-auto-width,
+.button.codicon {
   @apply min-w-[auto];
 }
 


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e6968f1</samp>

This pull request improves the UI of the Monaco editor by fixing some CSS issues for buttons and inputs. It modifies the file `src/css/tailwind.css` to adjust the layout and style of these elements.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at e6968f1</samp>

> _Inside the Monaco editor_
> _Some buttons and inputs looked poor_
> _So they tweaked the CSS_
> _To make them look their best_
> _And fixed the layout and style issues for sure_

### WHY

- fix custom css editor find widget style
<img width="948" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/15699954/477b7af0-b2a3-40db-a4e5-c4a1e13e602f">

- no box-shadow with find textarea
<img width="253" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/15699954/08d59749-ea1a-46ca-a38f-4b80b731b8c0">


### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e6968f1</samp>

*  Fix button width bug for codicons ([link](https://github.com/Crossbell-Box/xLog/pull/1008/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5L103-R104))
*  Override focus styles for Monaco editor inputs ([link](https://github.com/Crossbell-Box/xLog/pull/1008/files?diff=unified&w=0#diff-98c7783466e499ea1ebc74a559ecfc4dada7fbfbc92b9f65c29c09025182ade5R321-R325))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
