### PR TITLE
chore: cleanup deprecated colors in tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
     "prettier-package-json": "2.8.0",
     "prisma": "5.3.1",
     "tailwindcss": "3.3.3",
-    "tailwindcss-variable-colors": "0.0.1",
+    "tailwindcss-variable-colors": "0.0.2",
     "typescript": "5.2.2"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -518,8 +518,8 @@ devDependencies:
     specifier: 3.3.3
     version: 3.3.3
   tailwindcss-variable-colors:
-    specifier: 0.0.1
-    version: 0.0.1(tailwindcss@3.3.3)
+    specifier: 0.0.2
+    version: 0.0.2(tailwindcss@3.3.3)
   typescript:
     specifier: 5.2.2
     version: 5.2.2
@@ -11150,8 +11150,8 @@ packages:
       tailwindcss: 3.3.3
     dev: false
 
-  /tailwindcss-variable-colors@0.0.1(tailwindcss@3.3.3):
-    resolution: {integrity: sha512-LcEwheZC0uCKDQk2nLMpxc9BL8HRtU0TBhXbGU+nasmXXTQXWO5YXCm/XyoRBzUYkRwkIbRiP3NH0jhOUoDwDA==}
+  /tailwindcss-variable-colors@0.0.2(tailwindcss@3.3.3):
+    resolution: {integrity: sha512-Cr5A2sNM4KgRF2FINv3gDoAP1jh/2UAh69DkVX/ri8OMvvT9zahGghqybMheVgsJ9IoHLF4xuZVb0ZuK+edsog==}
     peerDependencies:
       tailwindcss: '>=3.3.0'
     dependencies:

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,18 @@ import { default as alwaysColor } from "tailwindcss/colors"
 
 import { addDynamicIconSelectors } from "@iconify/tailwind"
 
+const deprecatedColors = [
+  "lightBlue",
+  "warmGray",
+  "trueGray",
+  "coolGray",
+  "blueGray",
+] as const
+
+deprecatedColors.forEach((color) => {
+  delete alwaysColor[color]
+})
+
 const config: Config = {
   content: ["./src/**/*.tsx"],
   safelist: ["icon-[mingcute--link-line]", "icon-[mingcute--copy-2-line]"],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,30 +1,18 @@
 import { Config } from "tailwindcss"
 import {
   createVariableColors,
+  getDefaultColors,
   variableColorsPlugin,
 } from "tailwindcss-variable-colors"
-import { default as alwaysColor } from "tailwindcss/colors"
 
 import { addDynamicIconSelectors } from "@iconify/tailwind"
-
-const deprecatedColors = [
-  "lightBlue",
-  "warmGray",
-  "trueGray",
-  "coolGray",
-  "blueGray",
-] as const
-
-deprecatedColors.forEach((color) => {
-  delete alwaysColor[color]
-})
 
 const config: Config = {
   content: ["./src/**/*.tsx"],
   safelist: ["icon-[mingcute--link-line]", "icon-[mingcute--copy-2-line]"],
   darkMode: ["class", "html.dark"],
   theme: {
-    colors: createVariableColors(alwaysColor),
+    colors: createVariableColors(),
     extend: {
       boxShadow: {
         modal: `rgb(0 0 0 / 20%) 0px 0px 1px, rgb(0 0 0 / 20%) 0px 20px 40px`,
@@ -36,7 +24,7 @@ const config: Config = {
         border: "var(--border-color)",
         accent: "var(--theme-color)",
         hover: "var(--hover-color)",
-        always: alwaysColor as any,
+        always: getDefaultColors() as any,
       },
       spacing: {
         sidebar: `240px`,
@@ -92,7 +80,7 @@ const config: Config = {
     require("tailwindcss-animate"),
     require("tailwind-scrollbar-hide"),
     addDynamicIconSelectors(),
-    variableColorsPlugin(alwaysColor),
+    variableColorsPlugin(),
   ],
 }
 


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3aba022</samp>

Remove deprecated colors from `alwaysColor` object in `tailwind.config.ts`. This improves the compatibility with the latest Tailwind CSS version and reduces the size of the generated CSS file.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 3aba022</samp>

> _`alwaysColor` shrinks_
> _deprecated hues are removed_
> _a fresh spring palette_

### WHY

![ScreenShot 2023-10-06 21 42 44](https://github.com/Crossbell-Box/xLog/assets/38493346/643fc705-3e10-46dd-8742-53a3f8eff367)

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3aba022</samp>

* Remove deprecated colors from `alwaysColor` object in `tailwind.config.ts` ([link](https://github.com/Crossbell-Box/xLog/pull/1019/files?diff=unified&w=0#diff-655dc9e3d0aa561e3fa164bf48bd89cb0f5da65e0a567f8ebbf9dd791a0e7f40R10-R21))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
