### PR TITLE
Update Platform.tsx

### DIFF
--- a/src/components/site/Platform.tsx
+++ b/src/components/site/Platform.tsx
@@ -156,7 +156,7 @@ export const PlatformsSyncMap: {
     icon: "/assets/social/email.png",
     url: "mailto:{username}",
   },
-  500px: {
+  "500px": {
     name: "500px",
     url: "https://500px.com/p/{username}",
   },

--- a/src/components/site/Platform.tsx
+++ b/src/components/site/Platform.tsx
@@ -156,6 +156,10 @@ export const PlatformsSyncMap: {
     icon: "/assets/social/email.png",
     url: "mailto:{username}",
   },
+  500px: {
+    name: "500px",
+    url: "https://500px.com/p/{username}",
+  },
 }
 
 export const Platform = ({


### PR DESCRIPTION
add “500px”

### WHAT

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7eec16e</samp>

Added support for 500px platform in `Platform.tsx`. Users can now connect their 500px profiles to their xLog accounts.

<!--
copilot:poem
-->
### <samp>🤖 Generated by Copilot at 7eec16e</samp>

> _`platforms` array_
> _grows with `500px` object_
> _link photos in fall_

### WHY

<!-- author to complete -->

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7eec16e</samp>

* Add 500px platform to the list of supported platforms ([link](https://github.com/Crossbell-Box/xLog/pull/1034/files?diff=unified&w=0#diff-eef6c570745ee2897d4a9ca64eaf6ee0bff71a9323dbfc991c860534b9f4b208R159-R162))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
