### PR TITLE
feat: resources 

### DIFF
--- a/deploy/prod/deploy.yaml
+++ b/deploy/prod/deploy.yaml
@@ -101,11 +101,11 @@ spec:
           command: ["caddy", "run", "-config", "/app/Caddyfile"]
           resources:
             requests:
-              cpu: 50m
-              memory: 64Mi
-            limits:
               cpu: 100m
               memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           envFrom:
             - secretRef:
                 name: xlog-caddy

--- a/deploy/prod/hpa.yaml
+++ b/deploy/prod/hpa.yaml
@@ -1,4 +1,4 @@
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: xlog
@@ -16,4 +16,24 @@ spec:
         name: cpu
         target:
           type: Utilization
-          averageUtilization: 70
+          averageUtilization: 300
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: xlog-caddy
+  namespace: crossbell
+spec:
+  maxReplicas: 20
+  minReplicas: 3
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: xlog-caddy
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 300


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c24169</samp>

This pull request improves the scalability and reliability of the xLog service on Kubernetes by updating the `hpa.yaml` and `deploy.yaml` files in the `deploy/prod` directory. The changes adjust the apiVersion, scaling metrics, and resource allocations for the xlog-api and xlog-caddy deployments.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c24169</samp>

> _`xlog-api` grows_
> _more resources and pods_
> _autumn traffic surge_

### WHY

<!-- author to complete -->

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5c24169</samp>

* Increase the resource requests and limits for the xlog-api deployment to handle higher traffic and avoid throttling ([link](https://github.com/Crossbell-Box/xLog/pull/1040/files?diff=unified&w=0#diff-3c631447f79e3bf30a0d5f6a521b3cd281a9e84fa508f07448dcfbc180c6cf98L104-R108))
* Update the apiVersion for the HorizontalPodAutoscaler to v2, the stable version supported by Kubernetes 1.19 and above ([link](https://github.com/Crossbell-Box/xLog/pull/1040/files?diff=unified&w=0#diff-1552adc4bb724cbb277273088e330bf89c3a257df404af7f71a0586bf1d09991L1-R1))
* Increase the averageUtilization metric for the xlog-api HorizontalPodAutoscaler to 300% of the request, to improve the responsiveness and availability of the xlog-api service under high load ([link](https://github.com/Crossbell-Box/xLog/pull/1040/files?diff=unified&w=0#diff-1552adc4bb724cbb277273088e330bf89c3a257df404af7f71a0586bf1d09991L19-R39))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
