### PR TITLE
fix: solved the ssr issue.

### DIFF
--- a/src/app/[locale]/(home)/(activities)/hottest/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/hottest/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from "next"
+import { getLocale } from "next-intl/server"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
 
 import { HomeFeed } from "~/components/home/HomeFeed"
 import { APP_NAME } from "~/lib/env"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { prefetchGetFeed } from "~/queries/home.server"
 
 export const metadata: Metadata = {
@@ -13,10 +15,12 @@ export const metadata: Metadata = {
 
 export default async function HottestActivities() {
   const queryClient = getQueryClient()
+  const locale = (await getLocale()) as Language
   await prefetchGetFeed(
     {
       type: "hottest",
       daysInterval: 7,
+      translateTo: locale,
     },
     queryClient,
   )

--- a/src/app/[locale]/(home)/(activities)/latest/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/latest/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from "next"
+import { getLocale } from "next-intl/server"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
 
 import { HomeFeed } from "~/components/home/HomeFeed"
 import { APP_NAME } from "~/lib/env"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { prefetchGetFeed } from "~/queries/home.server"
 
 export const metadata: Metadata = {
@@ -13,9 +15,11 @@ export const metadata: Metadata = {
 
 export default async function LatestActivities() {
   const queryClient = getQueryClient()
+  const locale = (await getLocale()) as Language
   await prefetchGetFeed(
     {
       type: "latest",
+      translateTo: locale,
     },
     queryClient,
   )

--- a/src/app/[locale]/(home)/(activities)/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import { getLocale } from "next-intl/server"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
 
@@ -6,6 +7,7 @@ import { HomeFeed } from "~/components/home/HomeFeed"
 import ShortPreviewList from "~/components/site/ShortPreviewList"
 import { APP_NAME, APP_SLOGAN } from "~/lib/env"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { getPreviewShort, prefetchGetFeed } from "~/queries/home.server"
 
 export const metadata: Metadata = {
@@ -14,9 +16,11 @@ export const metadata: Metadata = {
 
 export default async function HomeActivities() {
   const queryClient = getQueryClient()
+  const locale = (await getLocale()) as Language
   await prefetchGetFeed(
     {
       type: "featured",
+      translateTo: locale,
     },
     queryClient,
   )

--- a/src/app/[locale]/(home)/(activities)/search/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/search/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import { getLocale } from "next-intl/server"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
 
@@ -6,6 +7,7 @@ import { SearchInput } from "~/components/common/SearchInput"
 import { HomeFeed } from "~/components/home/HomeFeed"
 import { APP_NAME } from "~/lib/env"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { prefetchGetFeed } from "~/queries/home.server"
 
 export function generateMetadata({
@@ -28,11 +30,13 @@ export default async function Search({
   }
 }) {
   const queryClient = getQueryClient()
+  const locale = (await getLocale()) as Language
   await prefetchGetFeed(
     {
       type: "search",
       searchKeyword: searchParams.q || undefined,
       searchType: "latest",
+      translateTo: locale,
     },
     queryClient,
   )

--- a/src/app/[locale]/(home)/(activities)/shorts/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/shorts/page.tsx
@@ -1,10 +1,12 @@
 import { Metadata } from "next"
+import { getLocale } from "next-intl/server"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
 
 import { HomeFeed } from "~/components/home/HomeFeed"
 import { APP_NAME } from "~/lib/env"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { prefetchGetFeed } from "~/queries/home.server"
 
 export const metadata: Metadata = {
@@ -13,9 +15,11 @@ export const metadata: Metadata = {
 
 export default async function LatestActivities() {
   const queryClient = getQueryClient()
+  const locale = (await getLocale()) as Language
   await prefetchGetFeed(
     {
       type: "shorts",
+      translateTo: locale,
     },
     queryClient,
   )

--- a/src/app/[locale]/(home)/(activities)/tag/[tag]/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/tag/[tag]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next"
+import { getLocale } from "next-intl/server"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
 
@@ -6,6 +7,7 @@ import { HomeFeed } from "~/components/home/HomeFeed"
 import ParticipateButton from "~/components/home/ParticipateButton"
 import { APP_NAME } from "~/lib/env"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { prefetchGetFeed } from "~/queries/home.server"
 
 export function generateMetadata({
@@ -30,10 +32,12 @@ export default async function Tag({
   params.tag = decodeURIComponent(params.tag)
 
   const queryClient = getQueryClient()
+  const locale = (await getLocale()) as Language
   await prefetchGetFeed(
     {
       type: "tag",
       tag: params.tag,
+      translateTo: locale,
     },
     queryClient,
   )

--- a/src/app/[locale]/(home)/(activities)/topic/[topic]/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/topic/[topic]/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from "next"
-import { getTranslations } from "next-intl/server"
+import { getLocale, getTranslations } from "next-intl/server"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
 
@@ -7,6 +7,7 @@ import { HomeFeed } from "~/components/home/HomeFeed"
 import ParticipateButton from "~/components/home/ParticipateButton"
 import { APP_NAME } from "~/lib/env"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { prefetchGetFeed } from "~/queries/home.server"
 
 import topics from "../../../../../../../data/topics.json"
@@ -36,10 +37,12 @@ export default async function Topic({
   const info = topics.find((t) => t.name === params.topic)
 
   const queryClient = getQueryClient()
+  const locale = (await getLocale()) as Language
   await prefetchGetFeed(
     {
       type: "topic",
       topic: params.topic,
+      translateTo: locale,
     },
     queryClient,
   )


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5a818dd</samp>

This pull request adds support for multiple languages for the feed items on various pages of the home activities section of the app. It uses the `getLocale` function to get the current locale from the request and passes it to the `prefetchGetFeed` function to fetch the translated feed items from the API. It modifies the files `src/app/[locale]/(home)/(activities)/*/*.tsx` to implement this feature.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5a818dd</samp>

> _Oh, we are the coders of the web, me lads_
> _And we fetch the feed items for the page_
> _We use the `getLocale` function well_
> _To get the language of the user's stage_

### WHY

<!-- author to complete -->

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5a818dd</samp>

*  Add `locale` parameter to `prefetchGetFeed` function to request translated feed items from API ([link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-f39d79c2280a1a27a047e794b5e044a9f3e292e10e38cef4ebca21bf97a4eea9L16-R23), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-4bc3830ed96ad41d40a537caaf3b39da6af4e5a58e10bdfb80fe593faffb0a73L16-R22), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-60a58e46bcd53e042c03383fa1c7086d6386566a06e2b6205e92cc1dd04cec58L17-R23), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-a669b62301510f08b5b96edb117527e7a0725eb224fc5928df08d0faeed293c5R39), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-7886f09b092934c53b8ccdcc37da3815614d70db71c8d42c02ce1894d0a9a1bfL16-R22), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-230e3aba077c225a0ca56bebd2193e07abbd8ceefa5822cbff45264cac6b0418L33-R40), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-042b1558a66bbb4dc7ee8bc9e17680025fee1d53fa656986dcf422526aa392a2L39-R45))
*  Import `getLocale` function from `next-intl/server` to get current locale of request in each page component ([link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-f39d79c2280a1a27a047e794b5e044a9f3e292e10e38cef4ebca21bf97a4eea9R2), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-4bc3830ed96ad41d40a537caaf3b39da6af4e5a58e10bdfb80fe593faffb0a73R2), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-60a58e46bcd53e042c03383fa1c7086d6386566a06e2b6205e92cc1dd04cec58R2), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-a669b62301510f08b5b96edb117527e7a0725eb224fc5928df08d0faeed293c5R2), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-7886f09b092934c53b8ccdcc37da3815614d70db71c8d42c02ce1894d0a9a1bfR2), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-230e3aba077c225a0ca56bebd2193e07abbd8ceefa5822cbff45264cac6b0418R2), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-042b1558a66bbb4dc7ee8bc9e17680025fee1d53fa656986dcf422526aa392a2L2-R2))
*  Import `Language` type from `~/lib/types` to use as type of `locale` variable in each page component ([link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-f39d79c2280a1a27a047e794b5e044a9f3e292e10e38cef4ebca21bf97a4eea9R9), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-4bc3830ed96ad41d40a537caaf3b39da6af4e5a58e10bdfb80fe593faffb0a73R9), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-60a58e46bcd53e042c03383fa1c7086d6386566a06e2b6205e92cc1dd04cec58R10), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-a669b62301510f08b5b96edb117527e7a0725eb224fc5928df08d0faeed293c5R10), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-7886f09b092934c53b8ccdcc37da3815614d70db71c8d42c02ce1894d0a9a1bfR9), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-230e3aba077c225a0ca56bebd2193e07abbd8ceefa5822cbff45264cac6b0418R10), [link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-042b1558a66bbb4dc7ee8bc9e17680025fee1d53fa656986dcf422526aa392a2R10))
*  Assign `locale` variable to result of `getLocale` function in `search/page.tsx` ([link](https://github.com/Crossbell-Box/xLog/pull/1115/files?diff=unified&w=0#diff-a669b62301510f08b5b96edb117527e7a0725eb224fc5928df08d0faeed293c5R33))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
