### PR TITLE
fix: Taginput bug

### DIFF
--- a/src/components/ui/TagInput.tsx
+++ b/src/components/ui/TagInput.tsx
@@ -59,7 +59,7 @@ export function TagInput({
     query === ""
       ? userTags
       : Array.from(new Set([query, ...userTags])).filter((tag) =>
-          tag
+          (tag ?? '')
             .toString()
             .toLowerCase()
             .replace(/\s+/g, "")


### PR DESCRIPTION
### WHAT

### WHY

通过后台导入markdown的文章，在编辑标签时，会报一个``TypeError: Cannot read properties of null (reading 'toString')``的错误
![image](https://github.com/Crossbell-Box/xLog/assets/41848811/33f43d29-380f-4048-be50-055ee963699c)
![image](https://github.com/Crossbell-Box/xLog/assets/41848811/a11a2518-ce09-441a-af08-d3400f76285f)
通过打印此时 ``tag`` 的值，发现 ``tag`` 的值为 ``null ``
![image](https://github.com/Crossbell-Box/xLog/assets/41848811/948e7881-b855-42a8-bd2d-5cb49d859287)

### HOW

### CLAIM REWARDS

xLog: https://moleft.xlog.app
Discord ID: moleft_cn


For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
