### PR TITLE
fix: combobox default value

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -61,7 +61,7 @@ export const Input = forwardRef(function Input<
     [className, hasAddon, hasPrefix, inputProps, isBlock, ref],
   )
 
-  const [selected, setSelected] = useState()
+  const [selected, setSelected] = useState(inputComponentProps.value)
   const [query, setQuery] = useState("")
   const filteredOptions = options
     ? query === ""


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

When navigating to the `settings/social-platforms` page, the platform name is lost unless navigated via a link.

![ScreenShot 2023-12-11 10 59 35](https://github.com/Crossbell-Box/xLog/assets/38493346/6036df7c-153e-40b2-ae0e-c28541b67699)

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
