### PR TITLE
fix: content in homepage scroll after postcard is open

### DIFF
--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -64,6 +64,7 @@ const Card = ({
           ? externalLink || ""
           : `${linkPrefix || ""}/${post.metadata?.content?.slug}${queryString}`
       }
+      scroll={false}
       className={cn(
         "xlog-post rounded-2xl flex flex-col items-center group relative",
         isShort


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 77dcb72</samp>

Added a `scroll` prop to the `Card` component to control its scrolling behavior. This fixes a layout issue with the `PostCard` component and the navigation bar.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 77dcb72</samp>

> _`Card` has `scroll` prop_
> _To avoid overlap with nav_
> _A crisp autumn fix_

### WHY

before

![ScreenShot 2023-12-12 16 37 34](https://github.com/Crossbell-Box/xLog/assets/38493346/68732b6c-0962-4f3d-8077-3054c2480c95)

after

![ScreenShot 2023-12-12 16 35 05](https://github.com/Crossbell-Box/xLog/assets/38493346/1b798641-fafe-4ab6-b919-80c690d1c1c3)

### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 77dcb72</samp>

* Add a `scroll` prop to the `Card` component to disable scrolling inside the card ([link](https://github.com/Crossbell-Box/xLog/pull/1132/files?diff=unified&w=0#diff-08902826ffbce5f61f80184493f753baea8584afeccdc639ee3efc86c0ae1dbeR67))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
