### PR TITLE
fix: Skip translation if the content is empty.

### DIFF
--- a/src/app/api/translate-note/route.ts
+++ b/src/app/api/translate-note/route.ts
@@ -88,8 +88,15 @@ const getOriginalTranslation = async (
       translationChains.set(`${modelSize}_${targetLang}`, chain)
     }
 
-    const t = await chain.call({ text: title })
-    const c = await chain.call({ text: content })
+    const t =
+      String(title).trim().length === 0
+        ? { text: "" }
+        : await chain.call({ text: title })
+
+    const c =
+      String(content).trim().length === 0
+        ? { text: "" }
+        : await chain.call({ text: content })
 
     console.timeEnd(`fetching translation ${cid}, ${targetLang}`)
 


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4532e69</samp>

Fix translation bug for empty notes. Add a check for empty title or content in `src/app/api/translate-note/route.ts` before calling the translation chain.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4532e69</samp>

> _Empty notes skipped_
> _`translate` saves API calls_
> _Winter of errors_

### WHY

If the content is empty, the translation should be skipped.

<img width="312" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/32405058/48c91903-147b-4162-bac0-22eb8f7eff6d">


### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 4532e69</samp>

*  Prevent translation of empty notes by adding a condition to check the title and content ([link](https://github.com/Crossbell-Box/xLog/pull/1136/files?diff=unified&w=0#diff-946a50dbfd0c0d8fec7bf31aa623684eb7df8b9116ccc4ef2953620219c722f1L91-R100))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
