### PR TITLE
feat: Display the translation information.

### DIFF
--- a/src/app/[locale]/site/[site]/[slug]/page.tsx
+++ b/src/app/[locale]/site/[site]/[slug]/page.tsx
@@ -10,6 +10,7 @@ import PostCover from "~/components/home/PostCover"
 import { OIAButton } from "~/components/site/OIAButton"
 import { PostFooter } from "~/components/site/PostFooter"
 import PostMeta from "~/components/site/PostMeta"
+import TranslationInfo from "~/components/site/TranslationInfo"
 import { SITE_URL } from "~/lib/env"
 import { getSiteLink } from "~/lib/helpers"
 import { toCid, toGateway } from "~/lib/ipfs-parser"
@@ -160,6 +161,7 @@ export default async function SitePagePage({
       <article>
         {type === "short" ? (
           <>
+            <TranslationInfo page={page} className="mb-4 mt-2" />
             <PostCover
               uniqueKey={`short-${page.characterId}-${page.noteId}`}
               images={images}

--- a/src/components/site/PostMeta.tsx
+++ b/src/components/site/PostMeta.tsx
@@ -7,7 +7,9 @@ import { RESERVED_TAGS } from "~/lib/constants"
 import { CSB_SCAN } from "~/lib/env"
 import { ExpandedCharacter, ExpandedNote, NoteType } from "~/lib/types"
 
-export default function PostMeta({
+import TranslationInfo from "./TranslationInfo"
+
+export default async function PostMeta({
   page,
   site,
   summary,
@@ -51,6 +53,7 @@ export default function PostMeta({
           type={page.metadata?.content?.tags?.[0] as NoteType}
         />
       </div>
+      <TranslationInfo page={page} />
       {summary && (
         <div className="xlog-post-summary border rounded-xl mt-5 p-4 space-y-2">
           <div className="font-bold text-zinc-700 flex items-center">

--- a/src/components/site/TranslationInfo.tsx
+++ b/src/components/site/TranslationInfo.tsx
@@ -1,0 +1,44 @@
+import { getLocale, getTranslations } from "next-intl/server"
+
+import { ExpandedNote } from "~/lib/types"
+import { cn } from "~/lib/utils"
+
+export default async function TranslationInfo({
+  page,
+  className,
+}: {
+  page: ExpandedNote
+  className?: string
+}) {
+  const t = await getTranslations()
+  const locale = await getLocale()
+
+  if (
+    page.metadata?.content?.translatedTo &&
+    page.metadata?.content?.translatedFrom &&
+    locale !== page.metadata?.content?.translatedFrom
+  ) {
+    return (
+      <div
+        className={cn(
+          "text-zinc-400 mt-5 space-x-5 flex justify-center",
+          className,
+        )}
+      >
+        <span className="xlog-post-views inline-flex items-center">
+          <i className="icon-[mingcute--translate-2-line] mr-[2px]" />
+          <span>
+            {t.rich("Translated by", {
+              from: () => (
+                <span>{t(page.metadata.content.translatedFrom)}</span>
+              ),
+              to: () => <span>{t(page.metadata.content.translatedTo)}</span>,
+            })}
+          </span>
+        </span>
+      </div>
+    )
+  }
+
+  return null
+}

--- a/src/lib/expand-unit.ts
+++ b/src/lib/expand-unit.ts
@@ -87,6 +87,9 @@ export const expandCrossbellNote = async ({
             expandedNote.metadata.content.title = translation.data
               .title as string
           }
+
+          expandedNote.metadata.content.translatedFrom = detectedLang
+          expandedNote.metadata.content.translatedTo = translateTo
         } catch (e) {
           // do nothing
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -102,6 +102,8 @@ export type ExpandedNote = NoteEntity & {
       contentHTML?: string
       disableAISummary?: boolean
       readingTime?: number
+      translatedFrom?: Language
+      translatedTo?: Language
     }
   }
   stat?: {

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -109,5 +109,10 @@
   "posts add": "Visitors can view the posts you have posted at homepage.",
   "shots add": "Visitors can view the shots you have posted at <link1>/shorts</link1>, you can <link2>add it to navigation menu</link2> so your visitors can find it.",
   "pages add": "Visitors can only access your page through its link, you can <link>add it to navigation menu</link> so your visitors can find it.",
-  "portfolios add": "Visitors can view the portfolios you have posted at homepage and <link1>/portfolios</link1>, you can <link2>add it to navigation menu</link2> so your visitors can find it."
+  "portfolios add": "Visitors can view the portfolios you have posted at homepage and <link1>/portfolios</link1>, you can <link2>add it to navigation menu</link2> so your visitors can find it.",
+  "Translated by": "This article has been translated from <from></from> into <to></to> through AI.",
+  "en": "English",
+  "ja": "Japanese",
+  "zh": "Chinese",
+  "zh-TW": "Traditional Chinese"
 }

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -211,5 +211,10 @@
   "Pull down to open the app": "ダウンロード済みですか？アプリを開くために引き下げてく",
   "Write a comment on the blockchain": "ブロックチェーンでコメントする",
   "Open in App": "アプリで開く",
-  "powered by": "<span>このサイトは　</span><name></name><span> によって作動します</span>"
+  "powered by": "<span>このサイトは　</span><name></name><span> によって作動します</span>",
+  "Translated by": "この記事はAIを通じて<from></from>から<to></to>に翻訳されました。",
+  "en": "英語",
+  "ja": "日本語",
+  "zh": "中国語",
+  "zh-TW": "繁体字中国語"
 }

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -372,5 +372,10 @@
   "Pull down to open the app": "已下載？下拉開啟應用程式",
   "Back to Home": "回到首頁",
   "Open in App": "在 App 中開啟",
-  "Search Posts": "搜尋文章"
+  "Search Posts": "搜尋文章",
+  "Translated by": "這篇文章透過AI由<from></from>翻譯成<to></to>。",
+  "en": "英文",
+  "ja": "日文",
+  "zh": "中文",
+  "zh-TW": "繁體中文"
 }

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -424,5 +424,10 @@
   "Open in App": "在 App 中打开",
   "Search Posts": "搜索文章",
   "URL (Optional)": "网址（可选）",
-  "More shorts": "更多图文"
+  "More shorts": "更多图文",
+  "Translated by": "这篇文章通过AI由<from></from>翻译成<to></to>。",
+  "en": "英语",
+  "ja": "日语",
+  "zh": "中文",
+  "zh-TW": "繁体中文"
 }


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 321761f</samp>

This pull request implements a new feature to display the translation information of translated pages and posts using the `TranslationInfo` component. It adds the component definition, the translation metadata, the layout and styling adjustments, and the translation strings for four languages. It modifies the `page.tsx` and `PostMeta.tsx` files to use the component, and the `expand-unit.ts` and `types.ts` files to include the translation metadata.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 321761f</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous component, `TranslationInfo`, to display_
> _The languages of the pages and posts he translated_
> _With the help of `next-intl` and `expand-unit`, his allies._

### WHY

<!-- author to complete -->

Added tips for translated articles.

<img width="438" alt="Screenshot 2023-12-12 at 20 37 55" src="https://github.com/Crossbell-Box/xLog/assets/32405058/0f568763-e0df-416a-9a73-f7b08bf843b5">
<img width="662" alt="Screenshot 2023-12-12 at 20 37 42" src="https://github.com/Crossbell-Box/xLog/assets/32405058/844d4111-65fe-42b0-8fad-e0d4af8e8da2">
<img width="607" alt="Screenshot 2023-12-12 at 20 37 32" src="https://github.com/Crossbell-Box/xLog/assets/32405058/000cfe1d-4691-46a2-bfa5-e82494d1a382">

Shorts also supported.
<img width="973" alt="Screenshot 2023-12-12 at 20 57 49" src="https://github.com/Crossbell-Box/xLog/assets/32405058/0a1cf2f8-04a0-46bd-bfd7-7fd5e0f3dffe">




### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 321761f</samp>

*  Define and import the `TranslationInfo` component to display the translation information of a page or a post if it is translated from another language ([link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-b1b0c32e8e28776be69d95071da8a42549fa274cf3acaf85c6b31f396cf0fb84R13), [link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-22f041acb0e3c878e0fc6ac9c0a59b9321bc199ab31c2df6cd3d14195141fe10L10-R12), [link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-b920df495bb349690ae60e3aaf8abed0d5f41e41030ce3c69459425600b4a97bR1-R44))
*  Render the `TranslationInfo` component with the `page` and `className` props in the `page.tsx` and `PostMeta.tsx` files, using the `next-intl` and `cn` functions to interpolate the translation message and apply the styles ([link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-b1b0c32e8e28776be69d95071da8a42549fa274cf3acaf85c6b31f396cf0fb84R164), [link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-22f041acb0e3c878e0fc6ac9c0a59b9321bc199ab31c2df6cd3d14195141fe10R56))
*  Assign the detected language and the translation target language to the `translatedFrom` and `translatedTo` properties of the `expandedNote.metadata.content` object in the `expandUnit` function, using some language detection and translation service or library ([link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-0802612f2ebfab23d2656fc2189271c4fef6451452a2bd7dacc8d8bcfe11e2e8R90-R92))
*  Update the `ExpandedNote` type definition to include the `translatedFrom` and `translatedTo` properties as optional `Language` type ([link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-b8b77f5be18cf56dca425b3a5b8e9d2e754dd37fe0e3612b95cd4e9bccda08a5R105-R106))
*  Add the translation strings and the language names for English, Japanese, Simplified Chinese, and Traditional Chinese to the `src/messages` folder, using the `<from>` and `<to>` tags to indicate where the language names should be inserted ([link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-8a2b44aca2c0d795c5537b872cf5ea0a558605c608e56e90837e96ad257817f2L112-R117), [link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-1f05384915b86b541c76fd62c87663609d082d93704464c4319c3db393ddc056L214-R219), [link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-b7bf89c786597bc459cf8794d6d0d899f5dbe6f6851bef9e5370f1a9f9696ee8L375-R380), [link](https://github.com/Crossbell-Box/xLog/pull/1137/files?diff=unified&w=0#diff-dc09281e6e748349764e4de940bef2328da48ea5075437b130b0d02c235b6cfcL427-R432))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
