### PR TITLE
feat: support to access the original content if not prefer the AI tra…

### DIFF
--- a/src/components/site/TranslationInfo.tsx
+++ b/src/components/site/TranslationInfo.tsx
@@ -3,6 +3,8 @@ import { getLocale, getTranslations } from "next-intl/server"
 import { ExpandedNote } from "~/lib/types"
 import { cn } from "~/lib/utils"
 
+import ViewOriginal from "./ViewOriginal"
+
 export default async function TranslationInfo({
   page,
   className,
@@ -35,6 +37,7 @@ export default async function TranslationInfo({
               to: () => <span>{t(page.metadata.content.translatedTo)}</span>,
             })}
           </span>
+          <ViewOriginal page={page} />
         </span>
       </div>
     )

--- a/src/components/site/ViewOriginal.tsx
+++ b/src/components/site/ViewOriginal.tsx
@@ -1,0 +1,21 @@
+"use client"
+
+import { useTranslations } from "next-intl"
+
+import { ExpandedNote } from "~/lib/types"
+
+export default function ViewOriginal({ page }: { page: ExpandedNote }) {
+  const t = useTranslations()
+
+  return (
+    <span
+      className="ml-1 underline cursor-pointer"
+      onClick={() => {
+        document.cookie = `NEXT_LOCALE=${page?.metadata?.content?.translatedFrom};`
+        window.location.reload()
+      }}
+    >
+      {t("View Original")}
+    </span>
+  )
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -111,6 +111,7 @@
   "pages add": "Visitors can only access your page through its link, you can <link>add it to navigation menu</link> so your visitors can find it.",
   "portfolios add": "Visitors can view the portfolios you have posted at homepage and <link1>/portfolios</link1>, you can <link2>add it to navigation menu</link2> so your visitors can find it.",
   "Translated by": "This article has been translated from <from></from> into <to></to> through AI.",
+  "View Original": "View Original",
   "en": "English",
   "ja": "Japanese",
   "zh": "Chinese",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -213,6 +213,7 @@
   "Open in App": "アプリで開く",
   "powered by": "<span>このサイトは　</span><name></name><span> によって作動します</span>",
   "Translated by": "この記事はAIを通じて<from></from>から<to></to>に翻訳されました。",
+  "View Original": "原文を表示",
   "en": "英語",
   "ja": "日本語",
   "zh": "中国語",

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -374,6 +374,7 @@
   "Open in App": "在 App 中開啟",
   "Search Posts": "搜尋文章",
   "Translated by": "這篇文章透過AI由<from></from>翻譯成<to></to>。",
+  "View Original": "查看原文",
   "en": "英文",
   "ja": "日文",
   "zh": "中文",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -426,6 +426,7 @@
   "URL (Optional)": "网址（可选）",
   "More shorts": "更多图文",
   "Translated by": "这篇文章通过AI由<from></from>翻译成<to></to>。",
+  "View Original": "查看原文",
   "en": "英语",
   "ja": "日语",
   "zh": "中文",


### PR DESCRIPTION
…nslation.

### WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 04f0ca8</samp>

Added a `ViewOriginal` component that allows users to see the original language of a translated note. Added translations for the component label in four languages.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 04f0ca8</samp>

> _Sing, O Muse, of the skillful coder who devised_
> _A wondrous `ViewOriginal` component, shining bright_
> _With many tongues and scripts, from English to Chinese_
> _And gave the users power to see the note's first light_

### WHY

<!-- author to complete -->
LT
<img width="1161" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/32405058/f4ed522d-f09d-41b0-a4d0-b5c890fb84ba">
<img width="1161" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/32405058/e59a5add-430c-4cfb-bef1-a86d545b3b18">


### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 04f0ca8</samp>

* Create a new component `ViewOriginal` to allow the user to switch to the original language of a translated note ([link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-d699f60003e760a09ea2880abf1d76813e96770b36036625fb20a8fa58aa66fbR1-R21))
* Import and render the `ViewOriginal` component inside the `TranslationInfo` component, passing the `page` prop with the note data ([link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-b920df495bb349690ae60e3aaf8abed0d5f41e41030ce3c69459425600b4a97bR6-R7),[link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-b920df495bb349690ae60e3aaf8abed0d5f41e41030ce3c69459425600b4a97bR40))
* Add the localized text for the "View Original" label to the `en.json`, `ja.json`, `zh-TW.json`, and `zh.json` files ([link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-8a2b44aca2c0d795c5537b872cf5ea0a558605c608e56e90837e96ad257817f2R114),[link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-1f05384915b86b541c76fd62c87663609d082d93704464c4319c3db393ddc056R216),[link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-b7bf89c786597bc459cf8794d6d0d899f5dbe6f6851bef9e5370f1a9f9696ee8R377),[link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-dc09281e6e748349764e4de940bef2328da48ea5075437b130b0d02c235b6cfcR429))
* Use the `useTranslations` hook to get the translated label in the `ViewOriginal` component ([link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-d699f60003e760a09ea2880abf1d76813e96770b36036625fb20a8fa58aa66fbR1-R21))
* Set a cookie with the original language code and reload the page when the `ViewOriginal` component is clicked, triggering the language switch ([link](https://github.com/Crossbell-Box/xLog/pull/1144/files?diff=unified&w=0#diff-d699f60003e760a09ea2880abf1d76813e96770b36036625fb20a8fa58aa66fbR1-R21))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
