### PR TITLE
fix: fixed the problem where the preview displayed incorrectly.

### DIFF
--- a/src/app/[locale]/@modal/(.)post/[site]/[slug]/page.tsx
+++ b/src/app/[locale]/@modal/(.)post/[site]/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { getLocale, getTranslations } from "next-intl/server"
+import { getTranslations } from "next-intl/server"
 import { notFound } from "next/navigation"
 
 import { dehydrate, Hydrate } from "@tanstack/react-query"
@@ -12,6 +12,7 @@ import { SiteHeader } from "~/components/site/SiteHeader"
 import { toCid } from "~/lib/ipfs-parser"
 import { isOnlyContent } from "~/lib/is-only-content"
 import getQueryClient from "~/lib/query-client"
+import { Language } from "~/lib/types"
 import { cn } from "~/lib/utils"
 import { fetchGetPage, getSummary } from "~/queries/page.server"
 import { fetchGetSite } from "~/queries/site.server"
@@ -22,6 +23,7 @@ export default async function SiteModal({
   params: {
     site: string
     slug: string
+    locale: Language
   }
 }) {
   const queryClient = getQueryClient()
@@ -33,6 +35,7 @@ export default async function SiteModal({
       characterId: site?.characterId,
       slug: params.slug,
       useStat: true,
+      translateTo: params.locale,
     },
     queryClient,
   )
@@ -46,13 +49,12 @@ export default async function SiteModal({
 
   const dehydratedState = dehydrate(queryClient)
 
-  const locale = await getLocale()
   const t = await getTranslations()
   let summary: string | undefined
   if (!page.metadata.content.disableAISummary) {
     summary = await getSummary({
       cid: toCid(page.metadata?.uri || ""),
-      lang: locale,
+      lang: params.locale,
     })
   }
   const onlyContent = isOnlyContent()


### PR DESCRIPTION
### WHAT

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5e55469</samp>

Simplified and improved language handling for modal post pages. Added `locale` and `translateTo` props to `page.tsx` to fetch and display data in the desired language.

<!--
copilot:poem
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5e55469</samp>

> _`locale` and `translateTo`_
> _fetch and display page data_
> _autumn leaves fall_

### WHY

<!-- author to complete -->
LT

## Before

<img width="368" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/32405058/6f63e33a-3905-407c-9e7c-91e172b7dd49">
<img width="1070" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/32405058/50791284-9cac-4059-b3f9-b68075dcc599">

## After

https://github.com/Crossbell-Box/xLog/assets/32405058/d7b59c82-23eb-4603-9104-f5ec9e40d21e




### HOW

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 5e55469</samp>

*  Remove unused `getLocale` import and add `Language` type import from `~/lib/types` module ([link](https://github.com/Crossbell-Box/xLog/pull/1145/files?diff=unified&w=0#diff-0f14a0af990d15ed609155ad753c6f94ba37f3e070224f9138c057c431c3ca0eL1-R1),[link](https://github.com/Crossbell-Box/xLog/pull/1145/files?diff=unified&w=0#diff-0f14a0af990d15ed609155ad753c6f94ba37f3e070224f9138c057c431c3ca0eR15))
*  Add `locale` property to `Params` type to indicate the language of the page from the URL path ([link](https://github.com/Crossbell-Box/xLog/pull/1145/files?diff=unified&w=0#diff-0f14a0af990d15ed609155ad753c6f94ba37f3e070224f9138c057c431c3ca0eR26))
*  Pass `params.locale` as `translateTo` option to `getPage` function to fetch page data in the target language ([link](https://github.com/Crossbell-Box/xLog/pull/1145/files?diff=unified&w=0#diff-0f14a0af990d15ed609155ad753c6f94ba37f3e070224f9138c057c431c3ca0eR38))
*  Replace `locale` variable with `params.locale` value in `getSummary` function call and remove redundant variable declaration ([link](https://github.com/Crossbell-Box/xLog/pull/1145/files?diff=unified&w=0#diff-0f14a0af990d15ed609155ad753c6f94ba37f3e070224f9138c057c431c3ca0eL49),[link](https://github.com/Crossbell-Box/xLog/pull/1145/files?diff=unified&w=0#diff-0f14a0af990d15ed609155ad753c6f94ba37f3e070224f9138c057c431c3ca0eL55-R57))

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
