### PR TITLE
docs: update required node version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ https://docs.github.com/en/get-started/quickstart/fork-a-repo
 
 ## Requirements
 
-- [Node.js](https://nodejs.org). Version needs to be >=15.
+- [Node.js](https://nodejs.org) 18.17 or later.
 - [pnpm](https://pnpm.io/) package manager.
 - [Docker](https://www.docker.com/) for running the cache database.
 

--- a/package.json
+++ b/package.json
@@ -211,7 +211,7 @@
     "typescript": "5.3.3"
   },
   "engines": {
-    "node": ">=15"
+    "node": ">=18.17.0"
   },
   "nextBundleAnalysis": {
     "budget": 358400,


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

Starting from Next.js 14, the node version cannot be less than 18.17 .

https://nextjs.org/docs/getting-started/installation

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
