### PR TITLE
fix: can't scroll to top when browsing post

### DIFF
--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -64,7 +64,7 @@ const Card = ({
           ? externalLink || ""
           : `${linkPrefix || ""}/${post.metadata?.content?.slug}${queryString}`
       }
-      scroll={false}
+      scroll={!linkPrefix}
       className={cn(
         "xlog-post rounded-2xl flex flex-col items-center group relative",
         isShort


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

fix issues caused by #1132 , it prevents you from scrolling to the top when browsing the blog

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
