### PR TITLE
fix: limit dashboard width

### DIFF
--- a/src/app/[locale]/dashboard/[subdomain]/layout-component.tsx
+++ b/src/app/[locale]/dashboard/[subdomain]/layout-component.tsx
@@ -418,7 +418,12 @@ export default function DashboardLayout({
             </div>
           )}
 
-          <div className="lg:p-3 w-full h-full">
+          <div
+            className={cn(
+              "lg:p-3 w-full h-full",
+              !isMobileLayout && "max-w-[calc(100vw-240px)]",
+            )}
+          >
             <div
               className={cn(
                 `${isMobileLayout ? "pt-16 flex-1" : "flex-1 min-w-0"}`,


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

Only one article has this problem, not sure why.

https://hyoban.xlog.app/dark-mode

before

![ScreenShot 2024-01-05 12 19 56](https://github.com/Crossbell-Box/xLog/assets/38493346/416b2190-24e5-4d05-80c7-7ccf33195673)

after

![ScreenShot 2024-01-05 12 16 39](https://github.com/Crossbell-Box/xLog/assets/38493346/28bd6d16-1052-475b-96a8-72af45477c78)

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
