### PR TITLE
fix: default visibility to draft

### DIFF
--- a/src/app/[locale]/dashboard/[subdomain]/editor/post-editor.tsx
+++ b/src/app/[locale]/dashboard/[subdomain]/editor/post-editor.tsx
@@ -113,7 +113,9 @@ export default function PostEditor() {
     disableAutofill: true,
   })
 
-  const [visibility, setVisibility] = useState<PageVisibilityEnum>()
+  const [visibility, setVisibility] = useState<PageVisibilityEnum>(
+    PageVisibilityEnum.Draft,
+  )
 
   useEffect(() => {
     if (page.isSuccess) {


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

When entering the new post page for the first time, the publish button will be incorrectly displayed as update.

![ScreenShot 2024-01-05 21 43 04](https://github.com/Crossbell-Box/xLog/assets/38493346/90823ba7-0a6c-4697-9097-cc93a905bb3f)

After

![ScreenShot 2024-01-05 21 47 13](https://github.com/Crossbell-Box/xLog/assets/38493346/4afc5b8c-eae1-477f-be93-8f8e4556bd30)

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
