### PR TITLE
fix: icon url

### DIFF
--- a/src/components/site/Platform.tsx
+++ b/src/components/site/Platform.tsx
@@ -45,7 +45,7 @@ export const PlatformsSyncMap: {
   },
   x_id: {
     name: "X",
-    icon: `${iconCDN}/x_/fff`,
+    icon: `${iconCDN}/x/_/fff`,
     url: "https://x.com/i/user/{username}",
   },
   pixiv: {


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

This icon link `https://icons.ly/x_/fff` does not exist. It should be `https://icons.ly/x/_/fff`.

Documentation: https://github.com/LitoMore/simple-icons-cdn

### HOW

copilot:walkthrough

### CLAIM REWARDS

xLog address: https://litomore-1788.xlog.app

Discord ID: litomore