### PR TITLE
fix: z-index of the editor toolbar is above the menu

### DIFF
--- a/src/app/[locale]/dashboard/[subdomain]/editor/post-editor.tsx
+++ b/src/app/[locale]/dashboard/[subdomain]/editor/post-editor.tsx
@@ -392,7 +392,7 @@ export default function PostEditor() {
           <>
             <header
               className={cn(
-                "flex justify-between absolute top-0 inset-x-0 z-[25] px-5 h-14 border-b items-center text-sm",
+                "flex justify-between absolute top-0 inset-x-0 px-5 h-14 border-b items-center text-sm",
                 isMobileLayout && "w-screen",
               )}
             >


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

When expanded menu, z-index of the editor toolbar is above it.

![CleanShot 2024-02-22 at 18 11 17@2x](https://github.com/Crossbell-Box/xLog/assets/95858419/fc1115a2-b412-47d1-9524-d0d011de6f67)

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

xLog Address: oili.xlog.app
Discord ID: wagagaha
