### PR TITLE
fix: simplify conditional expression

### DIFF
--- a/src/app/[locale]/(home)/(activities)/topic/[topic]/page.tsx
+++ b/src/app/[locale]/(home)/(activities)/topic/[topic]/page.tsx
@@ -55,7 +55,7 @@ export default async function Topic({
           {info?.includeTags[0]}
         </div>
         <p className="text-zinc-600">{t(info?.description || "")}</p>
-        {info?.includeKeywords?.length || 0 > 0 ? (
+        {info?.includeKeywords?.length ? (
           <p className="text-zinc-400 text-sm">
             {t("Topic Keywords")}: {info?.includeKeywords?.join(", ")}
           </p>


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

Remove the redundant clause `0 > 0` which is always false.

Length of `0` is falsy in JS, so the code still works as expected without it.

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

xLog address: 0x0431c0CE6873a5dA43E9d7b19b5d48932e402cBD