### PR TITLE
fix: incorrect label

### DIFF
--- a/src/components/dashboard/toolbars/ResizeImage.tsx
+++ b/src/components/dashboard/toolbars/ResizeImage.tsx
@@ -11,8 +11,8 @@ const action = (view: EditorView) => {
 }
 
 export const ResizeImage: ICommand = {
-  name: "image-size",
-  label: "Image Size",
+  name: "resize-image",
+  label: "Resize Image",
   icon: "i-mingcute-aspect-ratio-line",
   execute: ({ view }) => {
     action(view)

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -110,7 +110,7 @@
   "Link": "リンク",
   "Image": "画像",
   "Upload Image, Audio or Video": "画像、音声、動画をアップロード",
-  "ResizeImage": "画像のサイズを変更",
+  "Resize Image": "画像のサイズを変更",
   "Tip: xLog Flavored Markdown": "ヒント：xLog 風のマークダウン",
   "Preview": "プレビュー",
   "Publish": "公開",

--- a/src/messages/zh-TW.json
+++ b/src/messages/zh-TW.json
@@ -159,7 +159,7 @@
   "Link": "連結",
   "Image": "圖片",
   "Upload Image, Audio or Video": "上傳圖片、音頻或視頻",
-  "ImageSize": "調整圖片大小",
+  "Resize Image": "調整圖片大小",
   "Preview": "預覽",
   "Publish": "發布",
   "Update": "更新",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -174,7 +174,7 @@
   "Link": "链接",
   "Image": "图片",
   "Upload Image, Audio or Video": "上传图片、音频或视频",
-  "ImageSize": "调整图像大小",
+  "Resize Image": "调整图像大小",
   "Mention": "提及",
   "Tip: xLog Flavored Markdown": "帮助：xLog 风格的 Markdown",
   "Preview": "预览",


### PR DESCRIPTION
### WHAT

Fix the error label in my last contribution

### WHY

<img width="416" alt="Screenshot 2024-03-05 at 14 51 03" src="https://github.com/Crossbell-Box/xLog/assets/101612750/2e193e26-577b-4907-ad77-7268846fa643">

It led to the issue described above, where the Chinese page displayed English labels.

### HOW

copilot:walkthrough

