### PR TITLE
fix: postCover image doesn't  fit cover in iOS and macOS/Safari

### DIFF
--- a/src/components/home/PostCover.tsx
+++ b/src/components/home/PostCover.tsx
@@ -53,7 +53,7 @@ export default function PostCover({
                   <div className="text-[0px] size-full">
                     <Image
                       className={cn(
-                        "object-cover w-full sm:group-hover:scale-105 sm:transition-transform sm:duration-400 sm:ease-in-out bg-white",
+                        "object-cover size-full sm:group-hover:scale-105 sm:transition-transform sm:duration-400 sm:ease-in-out bg-white",
                         imgClassName,
                       )}
                       alt="cover"
@@ -80,7 +80,7 @@ export default function PostCover({
           </>
         ) : images?.length === 1 ? (
           <Image
-            className="object-cover w-full sm:group-hover:scale-105 sm:transition-transform sm:duration-400 sm:ease-in-out"
+            className="object-cover size-full sm:group-hover:scale-105 sm:transition-transform sm:duration-400 sm:ease-in-out"
             alt="cover"
             src={images[0]}
             width={624}


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY
The PostCard image set has a w-full classname to fit the box. It works well on normal devices, but it does not work on iOS and macOS/Safari. Below are some screenshots to show this issue more clearly.
Befor:
![0b029af469e62b03541db6101cdcbf33](https://github.com/Crossbell-Box/xLog/assets/15699954/f30c35c6-b506-43a7-89fb-c7cedaacdb5b)
After:
![WeChat09074fbc062321fd4f915b95d729f94a](https://github.com/Crossbell-Box/xLog/assets/15699954/7035d086-2f1b-42ba-b3ba-13216844d7a7)

### HOW

copilot:walkthrough

### CLAIM REWARDS

