### PR TITLE
feat: add debounce to platform icon

### DIFF
--- a/src/components/site/Platform.tsx
+++ b/src/components/site/Platform.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useDebounceEffect } from "ahooks"
 import { useEffect, useState } from "react"
 
 import { Tooltip } from "~/components/ui/Tooltip"
@@ -172,9 +173,19 @@ export const Platform = ({
   className?: string
 }) => {
   platform = platform.toLowerCase()
-  let link = PlatformsSyncMap[platform]?.url
 
-  switch (platform) {
+  const [debouncePlatform, setDebouncePlatform] = useState(platform)
+  useDebounceEffect(
+    () => {
+      setDebouncePlatform(platform)
+    },
+    [platform],
+    { wait: 500 },
+  )
+
+  let link = PlatformsSyncMap[debouncePlatform]?.url
+
+  switch (debouncePlatform) {
     case "mastodon":
     case "misskey":
     case "pleroma":
@@ -190,7 +201,7 @@ export const Platform = ({
 
   useEffect(() => {
     setShowImg(true)
-  }, [platform])
+  }, [debouncePlatform])
 
   return (
     <UniLink
@@ -198,19 +209,22 @@ export const Platform = ({
         "size-5 inline-flex hover:scale-110 ease align-middle mr-3 sm:mr-6 transition-transform",
         className,
       )}
-      key={platform + username}
+      key={debouncePlatform + username}
       href={link}
     >
       <Tooltip
-        label={`${PlatformsSyncMap[platform]?.name || platform}: ${username}`}
+        label={`${PlatformsSyncMap[debouncePlatform]?.name || debouncePlatform}: ${username}`}
         className="text-sm"
       >
         <span className="inline-flex items-center">
           {showImg ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
-              src={PlatformsSyncMap[platform]?.icon || `${iconCDN}/${platform}`}
-              alt={platform}
+              src={
+                PlatformsSyncMap[debouncePlatform]?.icon ||
+                `${iconCDN}/${debouncePlatform}`
+              }
+              alt={debouncePlatform}
               width={20}
               height={20}
               onError={() => setShowImg(false)}


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

Currently, the Simple Icons input will send a request to `icons.ly` every time press the key. It's not a good practice sending too many 404 requests.

There are bunch of requests on this UI. And it's consuming the Vercel resource of [LitoMore/simple-icons-cdn](https://github.com/LitoMore/simple-icons-cdn) rapidly. You may reach the rate limit in a short time.

Better to use a debounce for web requests to keep your stability.

### HOW

copilot:walkthrough

### CLAIM REWARDS

xLog address: https://litomore-1788.xlog.app

Discord ID: litomore
