### PR TITLE
fix: remove rss html render `a` with anchor element

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
     "react-string-replace": "1.1.1",
     "react-tweet": "3.2.1",
     "react-virtuoso": "4.7.10",
-    "rehype-autolink-headings": "7.1.0",
     "rehype-infer-description-meta": "2.0.0",
     "rehype-katex": "7.0.0",
     "rehype-raw": "7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -302,9 +302,6 @@ importers:
       react-virtuoso:
         specifier: 4.7.10
         version: 4.7.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      rehype-autolink-headings:
-        specifier: 7.1.0
-        version: 7.1.0
       rehype-infer-description-meta:
         specifier: 2.0.0
         version: 2.0.0
@@ -6017,9 +6014,6 @@ packages:
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
-
-  rehype-autolink-headings@7.1.0:
-    resolution: {integrity: sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==}
 
   rehype-infer-description-meta@2.0.0:
     resolution: {integrity: sha512-8MZjKRfQiNB5+Qpt0fS9bpjcKe+nhF5GOTHo0M5e+XdStDpcZxkSMMnCfNIlpNaOyIQ7Hu1qEaUxm8ZL1lYI1g==}
@@ -14002,15 +13996,6 @@ snapshots:
       define-properties: 1.2.1
       es-errors: 1.3.0
       set-function-name: 2.0.2
-
-  rehype-autolink-headings@7.1.0:
-    dependencies:
-      '@types/hast': 3.0.4
-      '@ungap/structured-clone': 1.2.0
-      hast-util-heading-rank: 3.0.0
-      hast-util-is-element: 3.0.0
-      unified: 11.0.4
-      unist-util-visit: 5.0.0
 
   rehype-infer-description-meta@2.0.0:
     dependencies:

--- a/src/app/[locale]/ColorSchemeInjector.tsx
+++ b/src/app/[locale]/ColorSchemeInjector.tsx
@@ -9,6 +9,7 @@ import {
 export const ColorSchemeInjector = () => {
   return (
     <script
+      suppressHydrationWarning
       dangerouslySetInnerHTML={{
         __html: `(() => {
 let DARK_MODE_STORAGE_KEY = "${DARK_MODE_STORAGE_KEY}";

--- a/src/components/ui/MarkdownRender.tsx
+++ b/src/components/ui/MarkdownRender.tsx
@@ -1,0 +1,31 @@
+import type { ExtraProps } from "hast-util-to-jsx-runtime"
+import React, {
+  type ClassAttributes,
+  type FC,
+  type HTMLAttributes,
+} from "react"
+
+export const createMarkdownHeaderComponent = (tag: string) => {
+  const MarkdownHeader: FC<
+    ClassAttributes<HTMLHeadingElement> &
+      HTMLAttributes<HTMLHeadingElement> &
+      ExtraProps
+  > = ({ children, ...rest }) => {
+    const Tag = tag as any
+
+    return (
+      <Tag {...rest}>
+        {children}
+        <a
+          className="xlog-anchor"
+          tabIndex={-1}
+          href={rest.id ? `#${rest.id}` : undefined}
+        >
+          #
+        </a>
+      </Tag>
+    )
+  }
+
+  return MarkdownHeader
+}

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -13,7 +13,6 @@ import {
 } from "react"
 import { toast } from "react-hot-toast"
 import { Fragment, jsx, jsxs } from "react/jsx-runtime"
-import rehypeAutolinkHeadings from "rehype-autolink-headings"
 import rehypeInferDescriptionMeta from "rehype-infer-description-meta"
 import rehypeKatex from "rehype-katex"
 import rehypeRaw from "rehype-raw"
@@ -38,6 +37,7 @@ import { VFile } from "vfile"
 import remarkCalloutDirectives from "@microflash/remark-callout-directives"
 
 import AdvancedImage from "~/components/ui/AdvancedImage"
+import { createMarkdownHeaderComponent } from "~/components/ui/MarkdownRender"
 import { isServerSide } from "~/lib/utils"
 
 import { transformers } from "./embed-transformers"
@@ -63,6 +63,14 @@ const APlayer = dynamic(() => import("~/components/ui/APlayer"))
 const DPlayer = dynamic(() => import("~/components/ui/DPlayer"))
 const RSS = dynamic(() => import("~/components/ui/RSS"))
 const ShikiRemark = dynamic(() => import("~/components/ui/ShikiRemark"))
+
+const HeadRenderMap = {
+  h1: createMarkdownHeaderComponent("h1"),
+  h2: createMarkdownHeaderComponent("h2"),
+  h3: createMarkdownHeaderComponent("h3"),
+  h4: createMarkdownHeaderComponent("h4"),
+  h5: createMarkdownHeaderComponent("h5"),
+}
 
 const memoedPreComponentMap = {} as Record<string, any>
 const hashCodeThemeKey = (codeTheme?: Record<string, any>): string => {
@@ -109,22 +117,22 @@ export const renderPageContent = ({
       .use(rehypeRaw)
       .use(rehypeIpfs)
       .use(rehypeSlug)
-      .use(rehypeAutolinkHeadings, {
-        behavior: "append",
-        properties: {
-          className: "xlog-anchor",
-          ariaHidden: true,
-          tabIndex: -1,
-        },
-        content(node) {
-          return [
-            {
-              type: "text",
-              value: "#",
-            },
-          ]
-        },
-      })
+      // .use(rehypeAutolinkHeadings, {
+      //   behavior: "append",
+      //   properties: {
+      //     className: "xlog-anchor",
+      //     ariaHidden: true,
+      //     tabIndex: -1,
+      //   },
+      //   content(node) {
+      //     return [
+      //       {
+      //         type: "text",
+      //         value: "#",
+      //       },
+      //     ]
+      //   },
+      // })
       .use(rehypeSanitize, strictMode ? undefined : sanitizeScheme)
       .use(rehypeTable)
       .use(rehypeExternalLink)
@@ -192,6 +200,16 @@ export const renderPageContent = ({
           // @ts-expect-error
           style: Style,
           rss: RSS,
+          // @ts-expect-error
+          h1: HeadRenderMap.h1,
+          // @ts-expect-error
+          h2: HeadRenderMap.h2,
+          // @ts-expect-error
+          h3: HeadRenderMap.h3,
+          // @ts-expect-error
+          h4: HeadRenderMap.h4,
+          // @ts-expect-error
+          h5: HeadRenderMap.h5,
 
           // @ts-expect-error
           pre: Pre,

--- a/src/markdown/index.ts
+++ b/src/markdown/index.ts
@@ -117,22 +117,7 @@ export const renderPageContent = ({
       .use(rehypeRaw)
       .use(rehypeIpfs)
       .use(rehypeSlug)
-      // .use(rehypeAutolinkHeadings, {
-      //   behavior: "append",
-      //   properties: {
-      //     className: "xlog-anchor",
-      //     ariaHidden: true,
-      //     tabIndex: -1,
-      //   },
-      //   content(node) {
-      //     return [
-      //       {
-      //         type: "text",
-      //         value: "#",
-      //       },
-      //     ]
-      //   },
-      // })
+
       .use(rehypeSanitize, strictMode ? undefined : sanitizeScheme)
       .use(rehypeTable)
       .use(rehypeExternalLink)


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

Remove 
![CleanShot 2024-06-07 at 8  57 44@2x](https://github.com/Crossbell-Box/xLog/assets/41265413/83287dfc-4a04-4017-809e-3165341169c0)
![CleanShot 2024-06-07 at 8  57 55@2x](https://github.com/Crossbell-Box/xLog/assets/41265413/e8fcfe41-929e-4a30-9d88-de4770a81929)


### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
