### PR TITLE
feat: enhanced netease transformer

### DIFF
--- a/src/markdown/embed-transformers/NetEaseMusic.ts
+++ b/src/markdown/embed-transformers/NetEaseMusic.ts
@@ -20,9 +20,10 @@ const parseLink = (url: string) => {
 }
 
 const getIFrame = (url: URL) => {
-  const { pathname, searchParams } = url
-  const isSong = pathname.includes("/song")
-  const id = searchParams.get("id")
+  const { pathname, searchParams, hash } = url
+  const isSong = pathname.includes("/song") || hash.includes("/song")
+  const [, , hashParsedId] = /#\/(song|album|playlist)\?id=(\d+)/.exec(hash) || []
+  const id = searchParams.get("id") || hashParsedId
   const { type } = parseLink(url.toString())
 
   const height = isSong ? 66 : 250
@@ -36,11 +37,12 @@ const getIFrame = (url: URL) => {
 export const NetEaseMusicTransformer: Transformer = {
   name: "NetEaseMusic",
   shouldTransform(url) {
-    const { host, pathname } = url
+    const { host, pathname, hash } = url
 
     return (
       host === "music.163.com" &&
-      includesSomeOfArray(pathname, ["/song", "/playlist", "/album"])
+      includesSomeOfArray(pathname, ["/song", "/playlist", "/album"]) ||
+      includesSomeOfArray(hash, ["/song", "/playlist", "/album"])
     )
   },
   getHTML(url) {


### PR DESCRIPTION
### WHAT


copilot:summary

copilot:poem

### WHY

<!-- author to complete -->

close: https://github.com/Crossbell-Box/xLog/issues/1918

It seems that the Netease Music web page router is working in hash route mode.
 
When I open a song URL in the browser, it is redirected to a hash mode URL immediately. 

e.g., [`https://music.163.com/song?id=2117757995`](https://music.163.com/song?id=2117757995) => [`https://music.163.com/#/song?id=2117757995`](https://music.163.com/#/song?id=2117757995). 

After I paste such a link into the xlog editor, I need to delete the hash and slash manually. 

With this PR merged, we can copy and paste the Netease URL directly without any changes. 

### HOW

copilot:walkthrough

### CLAIM REWARDS

<!-- author to complete -->
xlog: https://kisyphus.xlog.app/
discordID: 1042302651859218532
For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
