### PR TITLE
fix: in the dark mode make the github icon be white

### DIFF
--- a/src/components/home/PromotionLinks.tsx
+++ b/src/components/home/PromotionLinks.tsx
@@ -42,7 +42,7 @@ export default async function PromotionLinks({
       </Tooltip>
       {GITHUB_LINK && (
         <UniLink
-          className="flex-1 flex justify-center text-[#181717]"
+          className="flex-1 flex justify-center text-[#181717] dark:text-[#e6edf3]"
           href={GITHUB_LINK}
         >
           <span className="inline-block i-mingcute-github-fill text-2xl"></span>


### PR DESCRIPTION
the color is copy in github website
close https://github.com/Crossbell-Box/xLog/issues/1913

### WHAT

in the dark mode make the github icon be white

### WHY

<img width="352" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/44285412/eebebe7d-8aab-46e4-9108-c0807b2580be">

### HOW

<img width="381" alt="image" src="https://github.com/Crossbell-Box/xLog/assets/44285412/5385aa59-170b-4b1e-bd36-9a064ca20599">

### CLAIM REWARDS

<!-- author to complete -->
