### PR TITLE
fix: optimize the prompt words for front matter

### DIFF
--- a/src/queries/page.server.ts
+++ b/src/queries/page.server.ts
@@ -114,7 +114,7 @@ const getOriginalSummary = async ({
       if (!chain) {
         const prompt = new PromptTemplate({
           template: `Summarize this in "${summaryLang}" language:
-        "{text}", Ignore the front matter in Markdown. Summarize only the content after the second `---`.
+        "{text}", Ignore the front matter in Markdown. Summarize only the content after the second ---.
         CONCISE SUMMARY:`,
           inputVariables: ["text"],
         })

--- a/src/queries/page.server.ts
+++ b/src/queries/page.server.ts
@@ -114,7 +114,7 @@ const getOriginalSummary = async ({
       if (!chain) {
         const prompt = new PromptTemplate({
           template: `Summarize this in "${summaryLang}" language:
-        "{text}"
+        "{text}", Ignore the front matter in Markdown. Summarize only the content after the second `---`.
         CONCISE SUMMARY:`,
           inputVariables: ["text"],
         })

--- a/src/queries/page.server.ts
+++ b/src/queries/page.server.ts
@@ -113,8 +113,8 @@ const getOriginalSummary = async ({
       let chain = chains.get(summaryLang)
       if (!chain) {
         const prompt = new PromptTemplate({
-          template: `Summarize this in "${summaryLang}" language:
-        "{text}", Ignore the front matter in Markdown. Summarize only the content after the second ---.
+          template: `Summarize this in "${summaryLang}" language, If it is a markdown file that includes front matter, Ignore the front matter. Summarize only the content after the second ---:
+        "{text}"
         CONCISE SUMMARY:`,
           inputVariables: ["text"],
         })


### PR DESCRIPTION
Optimize the prompt words so that the AI ​​summary skips the Front Matter part 


### WHAT

copilot:summary

copilot:poem

### WHY

The original prompt might mistakenly identify the time in the Front Matter as part of the article content, such as in my article https://x.vriancao.top/a-simple-cf-workers-ai-example, where AI incorrectly recognized the time "May 1, 2024, 18:00:00" in the Front Matter as the time when Cloudflare launched Workers AI.

### HOW

copilot:walkthrough

### CLAIM REWARDS

https://x.vriancao.top/
Discord ID:vriancao

For first-time contributors, please leave your xLog address and Discord ID below to claim your rewards.
