### PR TITLE
fix: sidebar occlusion

### DIFF
--- a/src/app/[locale]/dashboard/[subdomain]/layout-component.tsx
+++ b/src/app/[locale]/dashboard/[subdomain]/layout-component.tsx
@@ -317,7 +317,9 @@ export default function DashboardLayout({
               {(isOpen) => <div>233</div>}
             </DashboardTopbar>
           ) : (
-            <div className={`w-sidebar transition-[width] relative shrink-0`}>
+            <div
+              className={`w-sidebar transition-[width] relative shrink-0 z-10`}
+            >
               <div
                 className={`w-sidebar transition-[width] fixed h-full flex flex-col`}
               >


### PR DESCRIPTION
### WHAT

<img width="182" alt="image" src="https://github.com/user-attachments/assets/dacd87b9-ca1c-4de0-baef-da5ac20d1be7">

<img width="706" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/3a2e5bf4-3a3c-48b3-b921-95c96a5569c4">

### WHY

<!-- author to complete -->
the sidebar is low level in this page

### HOW

add z-index on sidebar

### CLAIM REWARDS

