### PR TITLE
feat: add `discord user` to list of platforms

### DIFF
--- a/src/components/site/Platform.tsx
+++ b/src/components/site/Platform.tsx
@@ -97,6 +97,11 @@ export const PlatformsSyncMap: {
     icon: `${iconCDN}/discord`,
     url: "https://discord.gg/{username}",
   },
+  "discord user": {
+    name: "Discord User",
+    icon: `${iconCDN}/discord`,
+    url: "https://discord.com/users/{username}",
+  },
   xiaoyuzhou: {
     name: "小宇宙播客",
     icon: "/assets/social/xiaoyuzhou2.png",


### PR DESCRIPTION
### WHAT

copilot:summary

copilot:poem

### WHY

Currently xLog doesn’t support linking to someone’s discord user page. Only to a discord server.

### HOW

copilot:walkthrough

### CLAIM REWARDS

- xLog address: `wyl.xlog.app`
- Discord ID: `569402775625269248`